### PR TITLE
clippy: Remove needless return.

### DIFF
--- a/src/red.rs
+++ b/src/red.rs
@@ -17,11 +17,11 @@ enum RedChild<T: Types> {
 impl<T: Types> RedChild<T> {
     fn set(&mut self, node: RedNode<T>) -> &RedNode<T> {
         match self {
-            RedChild::Child(node) => return node,
+            RedChild::Child(node) => node,
             RedChild::Zigot(_) => {
                 *self = RedChild::Child(node);
                 match self {
-                    RedChild::Child(node) => return node,
+                    RedChild::Child(node) => node,
                     RedChild::Zigot(_) => unreachable!(),
                 }
             }


### PR DESCRIPTION
The value from this will be returned, so the `return` itself isn't
needed.