### PR TITLE
rename TreePtr -> TreeArc

### DIFF
--- a/examples/math.rs
+++ b/examples/math.rs
@@ -48,7 +48,7 @@ impl rowan::Types for Types {
 }
 
 type Node = rowan::SyntaxNode<Types>;
-type TreePtr<T> = rowan::TreePtr<Types, T>;
+type TreeArc<T> = rowan::TreeArc<Types, T>;
 
 struct Parser<I: Iterator<Item = (Token, SmolStr)>> {
     builder: GreenNodeBuilder<Types>,
@@ -99,7 +99,7 @@ impl<I: Iterator<Item = (Token, SmolStr)>> Parser<I> {
     fn parse_add(&mut self) {
         self.handle_operation(&[Token::Add, Token::Sub], Self::parse_mul)
     }
-    fn parse(mut self) -> TreePtr<Node> {
+    fn parse(mut self) -> TreeArc<Node> {
         self.builder.start_internal(NodeType::Marker(ASTKind::Root));
         self.parse_add();
         self.builder.finish_internal();

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -65,7 +65,7 @@ type GreenNodeBuilder = rowan::GreenNodeBuilder<STypes>;
 #[allow(type_alias_bounds)]
 type SyntaxNode = rowan::SyntaxNode<STypes>;
 
-type TreePtr<T> = rowan::TreePtr<STypes, T>;
+type TreeArc<T> = rowan::TreeArc<STypes, T>;
 
 use rowan::TransparentNewType;
 
@@ -73,7 +73,7 @@ use rowan::TransparentNewType;
 /// Note that `parse` does not return a `Result`:
 /// by design, syntax tree can be build even for
 /// completely invalid source code.
-fn parse(text: &str) -> TreePtr<Root> {
+fn parse(text: &str) -> TreeArc<Root> {
     struct Parser {
         /// input tokens, including whitespace,
         /// in *reverse* order.
@@ -92,7 +92,7 @@ fn parse(text: &str) -> TreePtr<Root> {
     }
 
     impl Parser {
-        fn parse(mut self) -> TreePtr<Root> {
+        fn parse(mut self) -> TreeArc<Root> {
             // Make sure that the root node covers all source
             self.builder.start_internal(ROOT);
             // Parse a list of S-expressions
@@ -241,9 +241,9 @@ macro_rules! ast_node {
                 }
             }
             #[allow(unused)]
-            fn to_owned(&self) -> TreePtr<Self> {
+            fn to_owned(&self) -> TreeArc<Self> {
                 let owned = self.0.to_owned();
-                TreePtr::cast(owned)
+                TreeArc::cast(owned)
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,37 +50,37 @@ pub trait Types: Send + Sync + 'static {
     type RootData: fmt::Debug + Send + Sync;
 }
 
-pub use crate::imp::{TransparentNewType, TreePtr};
+pub use crate::imp::{TransparentNewType, TreeArc};
 
-impl<T, N> Clone for TreePtr<T, N>
+impl<T, N> Clone for TreeArc<T, N>
 where
     T: Types,
     N: TransparentNewType<Repr = SyntaxNode<T>>,
 {
-    fn clone(&self) -> TreePtr<T, N> {
+    fn clone(&self) -> TreeArc<T, N> {
         let n: &N = &*self;
-        TreePtr::new(n)
+        TreeArc::new(n)
     }
 }
 
-impl<T, N> PartialEq<TreePtr<T, N>> for TreePtr<T, N>
+impl<T, N> PartialEq<TreeArc<T, N>> for TreeArc<T, N>
 where
     T: Types,
     N: TransparentNewType<Repr = SyntaxNode<T>>,
 {
-    fn eq(&self, other: &TreePtr<T, N>) -> bool {
+    fn eq(&self, other: &TreeArc<T, N>) -> bool {
         ptr::eq(self.inner, other.inner)
     }
 }
 
-impl<T, N> Eq for TreePtr<T, N>
+impl<T, N> Eq for TreeArc<T, N>
 where
     T: Types,
     N: TransparentNewType<Repr = SyntaxNode<T>>,
 {
 }
 
-impl<T, N> Hash for TreePtr<T, N>
+impl<T, N> Hash for TreeArc<T, N>
 where
     T: Types,
     N: TransparentNewType<Repr = SyntaxNode<T>>,
@@ -124,7 +124,7 @@ impl<T: Types> Hash for SyntaxNode<T> {
     }
 }
 
-impl<T, N> fmt::Debug for TreePtr<T, N>
+impl<T, N> fmt::Debug for TreeArc<T, N>
 where
     T: Types,
     N: TransparentNewType<Repr = SyntaxNode<T>> + fmt::Debug,
@@ -194,13 +194,13 @@ impl<T> Iterator for LeafAtOffset<T> {
 
 impl<T: Types> SyntaxNode<T> {
     /// Creates a new `SyntaxNode`, whihc becomes the root of the tree.
-    pub fn new(green: GreenNode<T>, data: T::RootData) -> TreePtr<T, SyntaxNode<T>> {
+    pub fn new(green: GreenNode<T>, data: T::RootData) -> TreeArc<T, SyntaxNode<T>> {
         Self::new_root(green, data)
     }
 
     /// Switch this node to owned flavor.
-    pub fn to_owned(&self) -> TreePtr<T, SyntaxNode<T>> {
-        TreePtr::new(self)
+    pub fn to_owned(&self) -> TreeArc<T, SyntaxNode<T>> {
+        TreeArc::new(self)
     }
 
     /// Get the green node for this node
@@ -465,6 +465,6 @@ mod tests {
         fn f<T: Send + Sync>() {}
         f::<GreenNode<SillyTypes>>();
         f::<SyntaxNode<SillyTypes>>();
-        f::<TreePtr<SillyTypes, SyntaxNode<SillyTypes>>>();
+        f::<TreeArc<SillyTypes, SyntaxNode<SillyTypes>>>();
     }
 }


### PR DESCRIPTION
It's the same amount of characters but gives much more information:

`TreePtr` could behave like a Box or Rc or Arc. TreeArc is clear about
semantics.

@jD91mZM2 what do you think about this naming?