### PR TITLE
Add de/serialization capability

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ colosseum = "0.2.2"
 parking_lot = "0.7.1"
 text_unit = "0.1.6"
 smol_str = "0.1.9"
+serde = { version = "1.0.89", optional = true, features = ["serde_derive"] }
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,12 +8,18 @@
 )]
 #![deny(unsafe_code)]
 
+#[cfg(feature = "serde")]
+extern crate serde;
+
 extern crate colosseum;
 extern crate parking_lot;
 extern crate smol_str;
 extern crate text_unit;
 
 mod green;
+
+#[cfg(feature = "serde")]
+mod ser;
 
 #[allow(unsafe_code)]
 mod imp;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,0 +1,86 @@
+use crate::*;
+use serde::{
+    de::{Deserializer, Error, MapAccess, Visitor},
+    ser::{SerializeMap, Serializer},
+    Deserialize, Serialize,
+};
+use std::{fmt, marker::PhantomData};
+
+///////////////////////////////////////////// ~ser~~~ /////////////////////////////////////////////
+
+#[derive(Serialize)]
+#[serde(untagged)]
+#[serde(bound(serialize = "T::Kind: Serialize"))]
+enum NodeContentSer<'a, T: Types> {
+    Leaf(&'a str),
+    Branch(&'a [GreenNode<T>]),
+}
+
+impl<T: Types> Serialize for GreenNode<T>
+where
+    T::Kind: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(1))?;
+        if let Some(text) = self.leaf_text() {
+            map.serialize_entry(&self.kind(), &NodeContentSer::<T>::Leaf(text.as_str()))?;
+        } else {
+            map.serialize_entry(&self.kind(), &NodeContentSer::Branch(self.children()))?;
+        }
+        map.end()
+    }
+}
+
+///////////////////////////////////////////// ~~~~de~ /////////////////////////////////////////////
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+#[serde(bound(deserialize = "T::Kind: Deserialize<'de>"))]
+enum NodeContentDe<'a, T: Types> {
+    Leaf(&'a str),
+    Branch(Vec<GreenNode<T>>),
+}
+
+struct NodeVisitor<T: Types>(PhantomData<GreenNode<T>>);
+
+impl<'de, T: Types> Visitor<'de> for NodeVisitor<T>
+where
+    T::Kind: Deserialize<'de>,
+{
+    type Value = GreenNode<T>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "a singleton map from the type kind to node content")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<GreenNode<T>, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let kind: T::Kind = map
+            .next_key()?
+            .ok_or_else(|| A::Error::custom("unexpected empty map"))?;
+        let value: NodeContentDe<T> = map.next_value()?;
+        Ok(match value {
+            NodeContentDe::Leaf(text) => GreenNode::new_leaf(kind, text.into()),
+            NodeContentDe::Branch(children) => {
+                GreenNode::new_branch(kind, children.into_boxed_slice())
+            }
+        })
+    }
+}
+
+impl<'de, T: Types> Deserialize<'de> for GreenNode<T>
+where
+    T::Kind: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_map(NodeVisitor(PhantomData))
+    }
+}

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -28,7 +28,7 @@ where
         if let Some(text) = self.leaf_text() {
             map.serialize_entry(&self.kind(), text.as_str())?;
         } else {
-            map.serialize_entry(&self.kind(), &NodeContentSer::Branch(self.children()))?;
+            map.serialize_entry(&self.kind(), self.children())?;
         }
         map.end()
     }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -26,7 +26,7 @@ where
     {
         let mut map = serializer.serialize_map(Some(1))?;
         if let Some(text) = self.leaf_text() {
-            map.serialize_entry(&self.kind(), &NodeContentSer::<T>::Leaf(text.as_str()))?;
+            map.serialize_entry(&self.kind(), text.as_str())?;
         } else {
             map.serialize_entry(&self.kind(), &NodeContentSer::Branch(self.children()))?;
         }


### PR DESCRIPTION
Add a simple "obviously correct" serde de/serialization impl behind the "serde" feature.

A node is represented as a singleton map from the syntax kind to an anonymous enumeration of either the leaf text or the branch's children. Due to the use of the anonymous enumeration, only self-describing formats can be deserialized from.

I suspect that this will be most useful for serializing to textual formats for comparison in tests, similar to the debug representation. (In fact, I have an adapter doing so in my usage.) Using a structured representation carries some benefit (editor folding support and such) and theoretically can enable more semantic diffing than a textual diff.

Omitting span information from the representation doesn't lose information as this representation instead represents the leaf text. This also means that inserting a new subtree doesn't change the representation before or after it, thus reducing the size of the diff.

Serialization and Deserialization are provided in the same file to help the obviousness of the implementation. Deserialization is mostly along for the ride with the Serialization, but could be dropped if not desired to be supported, as it does add significant complexity compared to the Serialize implementation.

An untagged enum is handled via serde_derive to avoid reimplementing that complexity locally, and to make it more likely to be correct.

-----

(needs tests)