### PR TITLE
Rewrite to separate tokens from interior nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/matklad/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees."
+edition = "2018"
 
 [dependencies]
 colosseum = "0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 colosseum = "0.2.2"
 parking_lot = "0.7.1"
 text_unit = "0.1.6"
-smol_str = "0.1.9"
+smol_str = "0.1.10"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+reorder_imports = false
+reorder_modules = false
+use_small_heuristics = "Max"

--- a/src/algo.rs
+++ b/src/algo.rs
@@ -1,0 +1,256 @@
+use std::ops::Range;
+
+use crate::{Types, generate, SyntaxNode, SyntaxElement, TextUnit, TextRange, SyntaxToken, SyntaxIndex};
+
+/// `WalkEvent` describes tree walking process.
+#[derive(Debug, Copy, Clone)]
+pub enum WalkEvent<T> {
+    /// Fired before traversing the node.
+    Enter(T),
+    /// Fired after the node is traversed.
+    Leave(T),
+}
+
+/// There might be zero, one or two leaves at a given offset.
+#[derive(Clone, Debug)]
+pub enum TokenAtOffset<T> {
+    /// No leaves at offset -- possible for the empty file.
+    None,
+    /// Only a single leaf at offset.
+    Single(T),
+    /// Offset is exactly between two leaves.
+    Between(T, T),
+}
+
+impl<T> TokenAtOffset<T> {
+    /// Convert to option, preferring the right leaf in case of a tie.
+    pub fn right_biased(self) -> Option<T> {
+        match self {
+            TokenAtOffset::None => None,
+            TokenAtOffset::Single(node) => Some(node),
+            TokenAtOffset::Between(_, right) => Some(right),
+        }
+    }
+    /// Convert to option, preferring the left leaf in case of a tie.
+    pub fn left_biased(self) -> Option<T> {
+        match self {
+            TokenAtOffset::None => None,
+            TokenAtOffset::Single(node) => Some(node),
+            TokenAtOffset::Between(left, _) => Some(left),
+        }
+    }
+}
+
+impl<T> Iterator for TokenAtOffset<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        match std::mem::replace(self, TokenAtOffset::None) {
+            TokenAtOffset::None => None,
+            TokenAtOffset::Single(node) => {
+                *self = TokenAtOffset::None;
+                Some(node)
+            }
+            TokenAtOffset::Between(left, right) => {
+                *self = TokenAtOffset::Single(right);
+                Some(left)
+            }
+        }
+    }
+}
+
+/// Iterator over node's children.
+#[derive(Debug)]
+pub struct SyntaxNodeChildren<'a, T: Types> {
+    parent: &'a SyntaxNode<T>,
+    iter: Range<u32>,
+}
+
+impl<'a, T: Types> Iterator for SyntaxNodeChildren<'a, T> {
+    type Item = &'a SyntaxNode<T>;
+
+    fn next(&mut self) -> Option<&'a SyntaxNode<T>> {
+        self.iter.next().map(|i| self.parent.get_child(SyntaxIndex(i)).unwrap())
+    }
+}
+
+#[derive(Debug)]
+pub struct SyntaxElementChildren<'a, T: Types> {
+    current: Option<SyntaxElement<'a, T>>,
+}
+
+impl<'a, T: Types> Iterator for SyntaxElementChildren<'a, T> {
+    type Item = SyntaxElement<'a, T>;
+
+    fn next(&mut self) -> Option<SyntaxElement<'a, T>> {
+        self.current.take().map(|current| {
+            self.current = current.next_sibling_or_token();
+            current
+        })
+    }
+}
+
+impl<T: Types> SyntaxNode<T> {
+    /// Get iterator over children, excluding tokens.
+    pub fn children(&self) -> SyntaxNodeChildren<'_, T> {
+        SyntaxNodeChildren { parent: self, iter: (0..self.children_len().0) }
+    }
+
+    /// Get iterator over children, including tokens.
+    pub fn children_with_tokens(&self) -> SyntaxElementChildren<'_, T> {
+        SyntaxElementChildren { current: self.first_child_or_token() }
+    }
+
+    /// All ancestors of the current node, including itself
+    pub fn ancestors(&self) -> impl Iterator<Item = &SyntaxNode<T>> {
+        generate(Some(self), |node| node.parent())
+    }
+
+    /// Traverse the subtree rooted at the current node (including the current
+    /// node) in preorder, excluding tokens.
+    pub fn preorder(&self) -> impl Iterator<Item = WalkEvent<&SyntaxNode<T>>> {
+        generate(Some(WalkEvent::Enter(self)), move |pos| {
+            let next = match *pos {
+                WalkEvent::Enter(node) => match node.first_child() {
+                    Some(child) => WalkEvent::Enter(child),
+                    None => WalkEvent::Leave(node),
+                },
+                WalkEvent::Leave(node) => {
+                    if node == self {
+                        return None;
+                    }
+                    match node.next_sibling() {
+                        Some(sibling) => WalkEvent::Enter(sibling),
+                        None => WalkEvent::Leave(node.parent().unwrap()),
+                    }
+                }
+            };
+            Some(next)
+        })
+    }
+
+    /// Traverse the subtree rooted at the current node (including the current
+    /// node) in preorder, including tokens.
+    pub fn preorder_with_tokens<'a>(
+        &'a self,
+    ) -> impl Iterator<Item = WalkEvent<SyntaxElement<'a, T>>> {
+        let start: SyntaxElement<T> = self.into();
+        generate(Some(WalkEvent::Enter(start)), move |pos| {
+            let next = match *pos {
+                WalkEvent::Enter(el) => match el {
+                    SyntaxElement::Node(node) => match node.first_child_or_token() {
+                        Some(child) => WalkEvent::Enter(child),
+                        None => WalkEvent::Leave(node.into()),
+                    },
+                    SyntaxElement::Token(token) => WalkEvent::Leave(token.into()),
+                },
+                WalkEvent::Leave(el) => {
+                    if el == start {
+                        return None;
+                    }
+                    match el.next_sibling_or_token() {
+                        Some(sibling) => WalkEvent::Enter(sibling),
+                        None => WalkEvent::Leave(el.parent().unwrap().into()),
+                    }
+                }
+            };
+            Some(next)
+        })
+    }
+
+    /// Returns common ancestor of the two nodes.
+    /// Precondition: nodes must be from the same tree.
+    pub fn common_ancestor<'a>(&'a self, other: &'a SyntaxNode<T>) -> &'a SyntaxNode<T> {
+        // TODO: use small-vec to memoize other's ancestors
+        for p in self.ancestors() {
+            if other.ancestors().any(|a| a == p) {
+                return p;
+            }
+        }
+        panic!("No common ancestor for {:?} and {:?}", self, other)
+    }
+
+    /// Find a token in the subtree corresponding to this node, which covers the offset.
+    /// Precondition: offset must be withing node's range.
+    pub fn token_at_offset<'a>(&'a self, offset: TextUnit) -> TokenAtOffset<SyntaxToken<'a, T>> {
+        // TODO: this could be faster if we first drill-down to node, and only
+        // then switch to token search. We should also replace explicit
+        // recursion with a loop.
+        let range = self.range();
+        assert!(
+            range.start() <= offset && offset <= range.end(),
+            "Bad offset: range {:?} offset {:?}",
+            range,
+            offset
+        );
+        if range.is_empty() {
+            return TokenAtOffset::None;
+        }
+
+        let mut children = self.children_with_tokens().filter(|child| {
+            let child_range = child.range();
+            !child_range.is_empty()
+                && (child_range.start() <= offset && offset <= child_range.end())
+        });
+
+        let left = children.next().unwrap();
+        let right = children.next();
+        assert!(children.next().is_none());
+
+        if let Some(right) = right {
+            match (left.token_at_offset(offset), right.token_at_offset(offset)) {
+                (TokenAtOffset::Single(left), TokenAtOffset::Single(right)) => {
+                    TokenAtOffset::Between(left, right)
+                }
+                _ => unreachable!(),
+            }
+        } else {
+            left.token_at_offset(offset)
+        }
+    }
+
+    /// Return the deepest node or token in the current subtree that fully
+    /// contains the range. If the range is empty and is contained in two leaf
+    /// nodes, either one can be returned. Precondition: range must be contained
+    /// withing the current node
+    pub fn covering_node(&self, range: TextRange) -> SyntaxElement<T> {
+        let mut res: SyntaxElement<T> = self.into();
+        loop {
+            assert!(
+                range.is_subrange(&res.range()),
+                "Bad range: node range {:?}, range {:?}",
+                res.range(),
+                range,
+            );
+            res = match res {
+                SyntaxElement::Token(_) => return res,
+                SyntaxElement::Node(node) => {
+                    match node
+                        .children_with_tokens()
+                        .find(|child| range.is_subrange(&child.range()))
+                    {
+                        Some(child) => child,
+                        None => return res,
+                    }
+                }
+            };
+        }
+    }
+
+    /// Number of memory bytes of occupied by subtree rooted at `self`.
+    pub fn memory_size_of_subtree(&self) -> usize {
+        std::mem::size_of::<Self>()
+            + self.green().memory_size_of_subtree()
+            + self.memory_size_of_red_children()
+    }
+}
+
+impl<'a, T: Types> SyntaxElement<'a, T> {
+    fn token_at_offset(&self, offset: TextUnit) -> TokenAtOffset<SyntaxToken<'a, T>> {
+        assert!(self.range().start() <= offset && offset <= self.range().end());
+        match *self {
+            SyntaxElement::Token(token) => TokenAtOffset::Single(token),
+            SyntaxElement::Node(node) => node.token_at_offset(offset),
+        }
+    }
+}

--- a/src/green.rs
+++ b/src/green.rs
@@ -2,21 +2,156 @@ use std::{mem::size_of, sync::Arc};
 
 use crate::{SmolStr, TextUnit, Types};
 
-/// `GreenNode` is an immutable syntax tree,
-/// which is cheap to update. It lacks parent
-/// pointers and information about offsets.
+/// Internal node in the immutable tree.
+/// It has other nodes and tokens as children.
 #[derive(Debug)]
-pub struct GreenNode<T: Types>(GreenNodeImpl<T>);
+pub struct GreenNode<T: Types> {
+    kind: T::Kind,
+    text_len: TextUnit,
+    //TODO: implement llvm::trailing_objects trick
+    children: Arc<[GreenElement<T>]>,
+}
+
+impl<T: Types> GreenNode<T> {
+    /// Creates new Node.
+    pub fn new(kind: T::Kind, children: Box<[GreenElement<T>]>) -> GreenNode<T> {
+        let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
+        GreenNode { kind, text_len, children: children.into() }
+    }
+
+    /// Kind of this node.
+    pub fn kind(&self) -> T::Kind {
+        self.kind
+    }
+
+    /// Length of the text, covered by this node.
+    pub fn text_len(&self) -> TextUnit {
+        self.text_len
+    }
+    /// Children of this node.
+    pub fn children(&self) -> &[GreenElement<T>] {
+        &self.children
+    }
+
+    /// Gets the child at index.
+    pub(crate) fn get_child(&self, index: GreenIndex) -> Option<&GreenElement<T>> {
+        self.children.get(index.0 as usize)
+    }
+
+    /// Number of memory bytes of occupied by subtree rooted at `self`.
+    pub(crate) fn memory_size_of_subtree(&self) -> usize {
+        let mut res = size_of::<Self>();
+        self.children().iter().for_each(|el| match el {
+            GreenElement::Token(token) => {
+                res += size_of::<GreenToken<T>>();
+                if token.text.len() > 22 {
+                    res += token.text.len();
+                }
+            }
+            GreenElement::Node(node) => res += node.memory_size_of_subtree(),
+        });
+
+        res
+    }
+}
 
 impl<T: Types> Clone for GreenNode<T> {
     fn clone(&self) -> GreenNode<T> {
-        GreenNode(match &self.0 {
-            GreenNodeImpl::Leaf { kind, text } => GreenNodeImpl::Leaf {
-                kind: *kind,
-                text: text.clone(),
-            },
-            GreenNodeImpl::Branch(branch) => GreenNodeImpl::Branch(Arc::clone(branch)),
-        })
+        GreenNode { kind: self.kind, text_len: self.text_len, children: Arc::clone(&self.children) }
+    }
+}
+
+/// Index into a green node, which might refer to either Token or Node
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) struct GreenIndex(pub(crate) u32);
+
+impl GreenIndex {
+    pub(crate) fn next(self) -> GreenIndex {
+        GreenIndex(self.0 + 1)
+    }
+
+    pub(crate) fn prev(self) -> GreenIndex {
+        // `GreenNode::get` does a bounds check anyway, so its ok to overflow
+        GreenIndex(self.0.wrapping_sub(1))
+    }
+}
+
+/// Leaf node in the immutable tree.
+#[derive(Debug)]
+pub struct GreenToken<T: Types> {
+    kind: T::Kind,
+    text: SmolStr,
+}
+
+impl<T: Types> GreenToken<T> {
+    /// Creates new Token.
+    pub fn new(kind: T::Kind, text: SmolStr) -> GreenToken<T> {
+        GreenToken { kind, text }
+    }
+    /// Kind of this Token.
+    pub fn kind(&self) -> T::Kind {
+        self.kind
+    }
+    /// Text of this Token.
+    pub fn text(&self) -> &SmolStr {
+        &self.text
+    }
+    /// Text of this Token.
+    pub fn text_len(&self) -> TextUnit {
+        TextUnit::from_usize(self.text.len())
+    }
+}
+
+impl<T: Types> Clone for GreenToken<T> {
+    fn clone(&self) -> GreenToken<T> {
+        GreenToken { kind: self.kind, text: self.text.clone() }
+    }
+}
+
+/// Leaf or internal node in the immutable tree.
+#[derive(Debug)]
+pub enum GreenElement<T: Types> {
+    /// Internal node.
+    Node(GreenNode<T>),
+    /// Leaf token.
+    Token(GreenToken<T>),
+}
+
+impl<T: Types> Clone for GreenElement<T> {
+    fn clone(&self) -> GreenElement<T> {
+        match self {
+            GreenElement::Node(it) => GreenElement::Node(it.clone()),
+            GreenElement::Token(it) => GreenElement::Token(it.clone()),
+        }
+    }
+}
+
+impl<T: Types> From<GreenNode<T>> for GreenElement<T> {
+    fn from(node: GreenNode<T>) -> GreenElement<T> {
+        GreenElement::Node(node)
+    }
+}
+
+impl<T: Types> From<GreenToken<T>> for GreenElement<T> {
+    fn from(token: GreenToken<T>) -> GreenElement<T> {
+        GreenElement::Token(token)
+    }
+}
+
+impl<T: Types> GreenElement<T> {
+    /// Returns kind of this element.
+    pub fn kind(&self) -> T::Kind {
+        match self {
+            GreenElement::Node(it) => it.kind(),
+            GreenElement::Token(it) => it.kind(),
+        }
+    }
+    /// Returns length of the text covered by this element.
+    pub fn text_len(&self) -> TextUnit {
+        match self {
+            GreenElement::Node(it) => it.text_len(),
+            GreenElement::Token(it) => it.text_len(),
+        }
     }
 }
 
@@ -24,43 +159,35 @@ impl<T: Types> Clone for GreenNode<T> {
 #[derive(Clone, Copy, Debug)]
 pub struct Checkpoint(usize);
 
-#[derive(Debug)]
-enum GreenNodeImpl<T: Types> {
-    Leaf { kind: T::Kind, text: SmolStr },
-    Branch(Arc<GreenBranch<T>>),
-}
-
 /// A builder for a green tree.
 #[derive(Debug)]
 pub struct GreenNodeBuilder<T: Types> {
     parents: Vec<(T::Kind, usize)>,
-    children: Vec<GreenNode<T>>,
+    children: Vec<GreenElement<T>>,
 }
 
 impl<T: Types> GreenNodeBuilder<T> {
     /// Creates new builder.
     pub fn new() -> Self {
-        GreenNodeBuilder {
-            parents: Vec::new(),
-            children: Vec::new(),
-        }
+        GreenNodeBuilder { parents: Vec::new(), children: Vec::new() }
     }
-    /// Adds new leaf to the current branch.
-    pub fn leaf(&mut self, kind: T::Kind, text: SmolStr) {
-        self.children.push(GreenNode::new_leaf(kind, text));
+    /// Adds new token to the current branch.
+    pub fn token(&mut self, kind: T::Kind, text: SmolStr) {
+        let token = GreenToken { kind, text };
+        self.children.push(token.into());
     }
-    /// Start new branch and make it current.
-    pub fn start_internal(&mut self, kind: T::Kind) {
+    /// Start new node and make it current.
+    pub fn start_node(&mut self, kind: T::Kind) {
         let len = self.children.len();
         self.parents.push((kind, len));
     }
     /// Finish current branch and restore previous
     /// branch as current.
-    pub fn finish_internal(&mut self) {
+    pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
         let children: Vec<_> = self.children.drain(first_child..).collect();
-        self.children
-            .push(GreenNode::new_branch(kind, children.into_boxed_slice()));
+        let node = GreenNode::new(kind, children.into_boxed_slice());
+        self.children.push(node.into());
     }
     /// Prepare for maybe wrapping the next node.
     /// The way wrapping works is that you first of all get a checkpoint,
@@ -81,7 +208,7 @@ impl<T: Types> GreenNodeBuilder<T> {
     }
     /// Wrap the previous branch marked by `checkpoint` in a new branch and
     /// make it current.
-    pub fn start_internal_at(&mut self, checkpoint: Checkpoint, kind: T::Kind) {
+    pub fn start_node_at(&mut self, checkpoint: Checkpoint, kind: T::Kind) {
         let Checkpoint(checkpoint) = checkpoint;
         assert!(
             checkpoint <= self.children.len(),
@@ -102,96 +229,9 @@ impl<T: Types> GreenNodeBuilder<T> {
     /// are paired!
     pub fn finish(mut self) -> GreenNode<T> {
         assert_eq!(self.children.len(), 1);
-        self.children.pop().unwrap()
-    }
-}
-
-impl<T: Types> GreenNode<T> {
-    /// Creates new leaf green node.
-    pub fn new_leaf(kind: T::Kind, text: SmolStr) -> GreenNode<T> {
-        GreenNode(GreenNodeImpl::Leaf { kind, text })
-    }
-    /// Creates new branch green node.
-    pub fn new_branch(kind: T::Kind, children: Box<[GreenNode<T>]>) -> GreenNode<T> {
-        GreenNode(GreenNodeImpl::Branch(Arc::new(GreenBranch::new(
-            kind, children,
-        ))))
-    }
-    /// Kind of this node.
-    pub fn kind(&self) -> T::Kind {
-        match &self.0 {
-            GreenNodeImpl::Leaf { kind, .. } => *kind,
-            GreenNodeImpl::Branch(b) => b.kind(),
+        match self.children.pop().unwrap() {
+            GreenElement::Node(node) => node,
+            GreenElement::Token(_) => panic!(),
         }
-    }
-    /// Length of the text, covered by this node.
-    pub fn text_len(&self) -> TextUnit {
-        match &self.0 {
-            GreenNodeImpl::Leaf { text, .. } => TextUnit::from(text.len() as u32),
-            GreenNodeImpl::Branch(b) => b.text_len(),
-        }
-    }
-    /// Children of this node, empty for leaves.
-    pub fn children(&self) -> &[GreenNode<T>] {
-        match &self.0 {
-            GreenNodeImpl::Leaf { .. } => &[],
-            GreenNodeImpl::Branch(b) => b.children(),
-        }
-    }
-    /// Text of this node, if it is a leaf, and
-    /// None otherwise.
-    pub fn leaf_text(&self) -> Option<&SmolStr> {
-        match &self.0 {
-            GreenNodeImpl::Leaf { text, .. } => Some(text),
-            GreenNodeImpl::Branch(_) => None,
-        }
-    }
-    /// Number of memory bytes of occupied by subtree rooted at `self`.
-    pub fn memory_size_of_subtree(&self) -> usize {
-        let mut res = size_of::<Self>();
-        match &self.0 {
-            GreenNodeImpl::Leaf { text, .. } => {
-                if text.len() > 22 {
-                    res += text.len();
-                }
-            }
-            GreenNodeImpl::Branch(branch) => {
-                res += size_of::<GreenBranch<T>>()
-                    + 2 * size_of::<usize>()
-                    + branch
-                        .children
-                        .iter()
-                        .map(|it| it.memory_size_of_subtree())
-                        .sum::<usize>();
-            }
-        }
-        res
-    }
-}
-
-#[derive(Debug)]
-struct GreenBranch<T: Types> {
-    text_len: TextUnit,
-    kind: T::Kind,
-    children: Box<[GreenNode<T>]>,
-}
-
-impl<T: Types> GreenBranch<T> {
-    fn new(kind: T::Kind, children: Box<[GreenNode<T>]>) -> GreenBranch<T> {
-        let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        GreenBranch {
-            text_len,
-            kind,
-            children,
-        }
-    }
-    fn kind(&self) -> T::Kind {
-        self.kind
-    }
-    fn text_len(&self) -> TextUnit {
-        self.text_len
-    }
-    fn children(&self) -> &[GreenNode<T>] {
-        &*self.children
     }
 }

--- a/src/green.rs
+++ b/src/green.rs
@@ -44,7 +44,7 @@ impl<T: Types> GreenNode<T> {
         self.children().iter().for_each(|el| match el {
             GreenElement::Token(token) => {
                 res += size_of::<GreenToken<T>>();
-                if token.text.len() > 22 {
+                if token.text.is_heap_allocated() {
                     res += token.text.len();
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,38 +4,36 @@
     missing_debug_implementations,
     unconditional_recursion,
     future_incompatible,
-    missing_docs
+    // missing_docs
 )]
 #![deny(unsafe_code)]
 
-extern crate colosseum;
-extern crate parking_lot;
-extern crate smol_str;
-extern crate text_unit;
-
-mod green;
-
-#[allow(unsafe_code)]
-mod imp;
 #[allow(unsafe_code)]
 mod swap_cell;
+mod green;
+#[allow(unsafe_code)]
+mod imp;
+mod syntax_token;
+mod syntax_node;
+mod syntax_element;
+mod algo;
 
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-    ops::Range,
-    ptr,
-};
+use std::fmt;
+use crate::{green::GreenIndex, imp::SyntaxIndex};
+
+// Reexport types for working with strings.
+// We might be too opinionated about these,
+// as a custom interner might work better,
+// but `SmolStr` is a pretty good default.
+pub use smol_str::SmolStr;
+pub use text_unit::{TextRange, TextUnit};
 
 pub use crate::{
-    green::{GreenNode, GreenNodeBuilder},
-    smol_str::SmolStr,
-
-    // Reexport types for working with strings.
-    // We might be too opinionated about these,
-    // as a custom interner might work better,
-    // but `SmolStr` is a pretty good default.
-    text_unit::{TextRange, TextUnit},
+    green::{GreenNode, GreenToken, GreenElement, GreenNodeBuilder},
+    imp::SyntaxNode,
+    syntax_token::SyntaxToken,
+    syntax_element::SyntaxElement,
+    algo::{WalkEvent, TokenAtOffset, SyntaxNodeChildren, SyntaxElementChildren},
 };
 
 /// `Types` customizes data, stored in the
@@ -53,44 +51,6 @@ pub trait Types: Send + Sync + 'static {
 
 pub use crate::imp::{TransparentNewType, TreeArc};
 
-impl<T, N> Clone for TreeArc<T, N>
-where
-    T: Types,
-    N: TransparentNewType<Repr = SyntaxNode<T>>,
-{
-    fn clone(&self) -> TreeArc<T, N> {
-        let n: &N = &*self;
-        TreeArc::new(n)
-    }
-}
-
-impl<T, N> PartialEq<TreeArc<T, N>> for TreeArc<T, N>
-where
-    T: Types,
-    N: TransparentNewType<Repr = SyntaxNode<T>>,
-{
-    fn eq(&self, other: &TreeArc<T, N>) -> bool {
-        ptr::eq(self.inner, other.inner)
-    }
-}
-
-impl<T, N> Eq for TreeArc<T, N>
-where
-    T: Types,
-    N: TransparentNewType<Repr = SyntaxNode<T>>,
-{
-}
-
-impl<T, N> Hash for TreeArc<T, N>
-where
-    T: Types,
-    N: TransparentNewType<Repr = SyntaxNode<T>>,
-{
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.inner.hash(state)
-    }
-}
-
 // NB: borrow requires that Eq & Hash for `Owned` are consistent with thouse for
 // `Borrowed`. This is true for `TreeArc`, but for a slightly peculiar reason:
 // it forces "identity" (comparisons of pointers) semantics on the contents.
@@ -101,40 +61,6 @@ where
 {
     fn borrow(&self) -> &N {
         &*self
-    }
-}
-
-pub use crate::imp::SyntaxNode;
-
-impl<T: Types> fmt::Debug for SyntaxNode<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(fmt, "{:?}@{:?}", self.kind(), self.range())
-    }
-}
-
-impl<T: Types> fmt::Display for SyntaxNode<T> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        self.preorder()
-            .filter_map(|event| match event {
-                WalkEvent::Enter(node) => Some(node),
-                _ => None,
-            })
-            .filter_map(|it| it.leaf_text())
-            .try_for_each(|it| write!(fmt, "{}", it))
-    }
-}
-
-// SyntaxNodes have identity equality semantics
-impl<T: Types> PartialEq<SyntaxNode<T>> for SyntaxNode<T> {
-    fn eq(&self, other: &SyntaxNode<T>) -> bool {
-        ptr::eq(self, other)
-    }
-}
-
-impl<T: Types> Eq for SyntaxNode<T> {}
-impl<T: Types> Hash for SyntaxNode<T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        (self as *const SyntaxNode<T>).hash(state)
     }
 }
 
@@ -149,317 +75,7 @@ where
     }
 }
 
-/// `WalkeEvent` describes tree walking process.
-#[derive(Debug, Copy, Clone)]
-pub enum WalkEvent<T> {
-    /// Fired before traversing the node.
-    Enter(T),
-    /// Fired after the node is traversed.
-    Leave(T),
-}
-
-/// There might be zero, one or two leaves at a given offset.
-#[derive(Clone, Debug)]
-pub enum LeafAtOffset<T> {
-    /// No leaves at offset -- possible for the empty file.
-    None,
-    /// Only a single leaf at offset.
-    Single(T),
-    /// Offset is exactly between two leaves.
-    Between(T, T),
-}
-
-impl<T> LeafAtOffset<T> {
-    /// Convert to option, preferring the right leaf in case of a tie.
-    pub fn right_biased(self) -> Option<T> {
-        match self {
-            LeafAtOffset::None => None,
-            LeafAtOffset::Single(node) => Some(node),
-            LeafAtOffset::Between(_, right) => Some(right),
-        }
-    }
-    /// Convert to option, preferring the left leaf in case of a tie.
-    pub fn left_biased(self) -> Option<T> {
-        match self {
-            LeafAtOffset::None => None,
-            LeafAtOffset::Single(node) => Some(node),
-            LeafAtOffset::Between(left, _) => Some(left),
-        }
-    }
-}
-
-impl<T> Iterator for LeafAtOffset<T> {
-    type Item = T;
-
-    fn next(&mut self) -> Option<T> {
-        match std::mem::replace(self, LeafAtOffset::None) {
-            LeafAtOffset::None => None,
-            LeafAtOffset::Single(node) => {
-                *self = LeafAtOffset::None;
-                Some(node)
-            }
-            LeafAtOffset::Between(left, right) => {
-                *self = LeafAtOffset::Single(right);
-                Some(left)
-            }
-        }
-    }
-}
-
-impl<T: Types> ToOwned for SyntaxNode<T> {
-    type Owned = TreeArc<T, SyntaxNode<T>>;
-    fn to_owned(&self) -> TreeArc<T, SyntaxNode<T>> {
-        TreeArc::new(self)
-    }
-}
-
-impl<T: Types> SyntaxNode<T> {
-    /// Creates a new `SyntaxNode`, whihc becomes the root of the tree.
-    pub fn new(green: GreenNode<T>, data: T::RootData) -> TreeArc<T, SyntaxNode<T>> {
-        Self::new_root(green, data)
-    }
-
-    /// Get the green node for this node
-    pub fn green(&self) -> &GreenNode<T> {
-        &self.green
-    }
-    /// Get the **root** node but with the children replaced. See `replace_with`.
-    pub fn replace_children(&self, children: Box<[GreenNode<T>]>) -> GreenNode<T> {
-        self.replace_self(GreenNode::new_branch(self.kind(), children))
-    }
-
-    /// Returns a green tree, equal to the green tree this node
-    /// belongs two, except with this node substitute. The complexity
-    /// of operation is proportional to the depth of the tree
-    /// TODO: naming is unfortunate, the return value is not *current*
-    /// node, it is the new root node.
-    pub fn replace_self(&self, green: GreenNode<T>) -> GreenNode<T> {
-        assert_eq!(self.kind(), green.kind());
-        match self.parent() {
-            None => green,
-            Some(parent) => {
-                let children: Vec<_> = parent
-                    .children()
-                    .map(|child| {
-                        if child == self {
-                            green.clone()
-                        } else {
-                            child.green.clone()
-                        }
-                    })
-                    .collect();
-                let new_parent = GreenNode::new_branch(parent.kind(), children.into_boxed_slice());
-                parent.replace_self(new_parent)
-            }
-        }
-    }
-
-    /// Returns `true` if this node is a leaf node.
-    pub fn is_leaf(&self) -> bool {
-        self.green.leaf_text().is_some()
-    }
-
-    /// Text of this node if it is a leaf.
-    // Only for `RefRoot` to extend lifetime to `'a`.
-    pub fn leaf_text<'a>(&'a self) -> Option<&'a SmolStr> {
-        self.green.leaf_text()
-    }
-
-    /// Get root data.
-    pub fn root_data(&self) -> &T::RootData {
-        &self.root().data
-    }
-
-    /// Get kind of this node.
-    pub fn kind(&self) -> T::Kind {
-        self.green.kind()
-    }
-
-    /// Get text range, covered by this node.
-    pub fn range(&self) -> TextRange {
-        TextRange::offset_len(self.start_offset(), self.green.text_len())
-    }
-
-    /// Get the parent node.
-    pub fn parent(&self) -> Option<&SyntaxNode<T>> {
-        self.parent_impl()
-    }
-
-    /// Get first child.
-    pub fn first_child(&self) -> Option<&SyntaxNode<T>> {
-        self.get_child(0)
-    }
-
-    /// Get last child.
-    pub fn last_child(&self) -> Option<&SyntaxNode<T>> {
-        let n = self.n_children();
-        let n = n.checked_sub(1)?;
-        self.get_child(n)
-    }
-
-    /// Get next sibling.
-    pub fn next_sibling(&self) -> Option<&SyntaxNode<T>> {
-        let parent = self.parent()?;
-        let next_sibling_idx = self.index_in_parent()? + 1;
-        parent.get_child(next_sibling_idx)
-    }
-
-    /// Get previous sibling.
-    pub fn prev_sibling(&self) -> Option<&SyntaxNode<T>> {
-        let parent = self.parent()?;
-        let prev_sibling_idx = self.index_in_parent()?.checked_sub(1)?;
-        parent.get_child(prev_sibling_idx)
-    }
-
-    /// Get iterator over children.
-    pub fn children(&self) -> SyntaxNodeChildren<T> {
-        SyntaxNodeChildren {
-            parent: self,
-            iter: (0..self.n_children()),
-        }
-    }
-
-    /// All ancestors of the current node, including itself
-    pub fn ancestors(&self) -> impl Iterator<Item = &SyntaxNode<T>> {
-        generate(Some(self), |node| node.parent())
-    }
-
-    /// Traverse the subtree rooted at the current node (including the current
-    /// node) in preorder.
-    pub fn preorder(&self) -> impl Iterator<Item = WalkEvent<&SyntaxNode<T>>> {
-        generate(Some(WalkEvent::Enter(self)), move |pos| {
-            let next = match *pos {
-                WalkEvent::Enter(node) => match node.first_child() {
-                    Some(child) => WalkEvent::Enter(child),
-                    None => WalkEvent::Leave(node),
-                },
-                WalkEvent::Leave(node) => {
-                    if node == self {
-                        return None;
-                    }
-                    match node.next_sibling() {
-                        Some(sibling) => WalkEvent::Enter(sibling),
-                        None => WalkEvent::Leave(node.parent().unwrap()),
-                    }
-                }
-            };
-            Some(next)
-        })
-    }
-
-    /// Returns common ancestor of the two nodes.
-    /// Precondition: nodes must be from the same tree.
-    pub fn common_ancestor<'a>(&'a self, other: &'a SyntaxNode<T>) -> &'a SyntaxNode<T> {
-        // TODO: use small-vec to memoize other's ancestors
-        for p in self.ancestors() {
-            if other.ancestors().any(|a| a == p) {
-                return p;
-            }
-        }
-        panic!("No common ancestor for {:?} and {:?}", self, other)
-    }
-
-    /// Find a leaf in the subtree corresponding to this node, which covers the offset.
-    /// Precondition: offset must be withing node's range.
-    pub fn leaf_at_offset(&self, offset: TextUnit) -> LeafAtOffset<&SyntaxNode<T>> {
-        // TODO: replace with non-recursive implementation
-        let range = self.range();
-        assert!(
-            range.start() <= offset && offset <= range.end(),
-            "Bad offset: range {:?} offset {:?}",
-            range,
-            offset
-        );
-        if range.is_empty() {
-            return LeafAtOffset::None;
-        }
-
-        if self.is_leaf() {
-            return LeafAtOffset::Single(self);
-        }
-
-        let mut children = self.children().filter(|child| {
-            let child_range = child.range();
-            !child_range.is_empty()
-                && (child_range.start() <= offset && offset <= child_range.end())
-        });
-
-        let left = children.next().unwrap();
-        let right = children.next();
-        assert!(children.next().is_none());
-
-        if let Some(right) = right {
-            match (left.leaf_at_offset(offset), right.leaf_at_offset(offset)) {
-                (LeafAtOffset::Single(left), LeafAtOffset::Single(right)) => {
-                    LeafAtOffset::Between(left, right)
-                }
-                _ => unreachable!(),
-            }
-        } else {
-            left.leaf_at_offset(offset)
-        }
-    }
-
-    /// Return the deepest node in the current subtree that fully contains the range.
-    /// If the range is empty and is contained in two leaf nodes, either one can be returned.
-    /// Precondition: range must be contained withing the current node
-    pub fn covering_node(&self, range: TextRange) -> &SyntaxNode<T> {
-        let mut res = self;
-        loop {
-            assert!(
-                range.is_subrange(&res.range()),
-                "Bad range: node range {:?}, range {:?}",
-                res.range(),
-                range,
-            );
-            res = match res
-                .children()
-                .find(|child| range.is_subrange(&child.range()))
-            {
-                Some(child) => child,
-                None => return res,
-            }
-        }
-    }
-
-    /// Number of memory bytes of occupied by subtree rooted at `self`.
-    pub fn memory_size_of_subtree(&self) -> usize {
-        std::mem::size_of::<Self>()
-            + self.green().memory_size_of_subtree()
-            + self.memory_size_of_red_children()
-    }
-
-    pub(crate) fn start_offset(&self) -> TextUnit {
-        match &self.parent {
-            None => 0.into(),
-            Some(p) => p.start_offset,
-        }
-    }
-
-    pub(crate) fn n_children(&self) -> usize {
-        self.green.children().len()
-    }
-
-    pub(crate) fn index_in_parent(&self) -> Option<usize> {
-        Some(self.parent.as_ref()?.index_in_parent as usize)
-    }
-}
-
-/// Iterator over node's children.
-#[derive(Debug)]
-pub struct SyntaxNodeChildren<'a, T: Types> {
-    parent: &'a SyntaxNode<T>,
-    iter: Range<usize>,
-}
-
-impl<'a, T: Types> Iterator for SyntaxNodeChildren<'a, T> {
-    type Item = &'a SyntaxNode<T>;
-
-    fn next(&mut self) -> Option<&'a SyntaxNode<T>> {
-        self.iter.next().map(|i| self.parent.get_child(i).unwrap())
-    }
-}
-
+// FIXME: replace with successors once it is stable
 fn generate<'a, T: 'a, F: Fn(&T) -> Option<T> + 'a>(
     seed: Option<T>,
     step: F,
@@ -479,7 +95,7 @@ mod tests {
     #[derive(Clone, Copy)]
     enum SillyTypes {}
     impl Types for SillyTypes {
-        type Kind = u8;
+        type Kind = u16;
         type RootData = ();
     }
 
@@ -489,5 +105,18 @@ mod tests {
         f::<GreenNode<SillyTypes>>();
         f::<SyntaxNode<SillyTypes>>();
         f::<TreeArc<SillyTypes, SyntaxNode<SillyTypes>>>();
+    }
+
+    #[test]
+    fn test_size_of() {
+        use std::mem::size_of;
+
+        eprintln!("GreenNode    {}", size_of::<GreenNode<SillyTypes>>());
+        eprintln!("GreenToken   {}", size_of::<GreenToken<SillyTypes>>());
+        eprintln!("GreenElement {}", size_of::<GreenElement<SillyTypes>>());
+        eprintln!();
+        eprintln!("SyntaxNode    {}", size_of::<SyntaxNode<SillyTypes>>());
+        eprintln!("SyntaxToken   {}", size_of::<SyntaxToken<SillyTypes>>());
+        eprintln!("SyntaxElement {}", size_of::<SyntaxElement<SillyTypes>>());
     }
 }

--- a/src/swap_cell.rs
+++ b/src/swap_cell.rs
@@ -19,10 +19,7 @@ pub(crate) struct SwapCell<U, V> {
 
 impl<U, V> SwapCell<U, V> {
     pub(crate) fn new(seed: U) -> SwapCell<U, V> {
-        SwapCell {
-            once: ONCE_INIT,
-            state: UnsafeCell::new(State::Uninit(seed)),
-        }
+        SwapCell { once: ONCE_INIT, state: UnsafeCell::new(State::Uninit(seed)) }
     }
 
     pub(crate) fn get_mut(&mut self) -> Option<&mut V> {

--- a/src/syntax_element.rs
+++ b/src/syntax_element.rs
@@ -1,0 +1,99 @@
+use std::hash::{Hash, Hasher};
+
+use crate::{Types, SyntaxNode, SyntaxToken, TextRange};
+
+/// Either a SyntaxToken or SyntaxNode.
+#[derive(Debug)]
+pub enum SyntaxElement<'a, T: Types> {
+    Node(&'a SyntaxNode<T>),
+    Token(SyntaxToken<'a, T>),
+}
+
+impl<'a, T: Types> Clone for SyntaxElement<'a, T> {
+    fn clone(&self) -> SyntaxElement<'a, T> {
+        *self
+    }
+}
+impl<'a, T: Types> Copy for SyntaxElement<'a, T> {}
+
+impl<'a, T: Types> PartialEq<SyntaxElement<'a, T>> for SyntaxElement<'a, T> {
+    fn eq(&self, other: &SyntaxElement<T>) -> bool {
+        match (self, other) {
+            (SyntaxElement::Node(n1), SyntaxElement::Node(n2)) => n1 == n2,
+            (SyntaxElement::Token(t1), SyntaxElement::Token(t2)) => t1 == t2,
+            _ => false,
+        }
+    }
+}
+impl<'a, T: Types> Eq for SyntaxElement<'a, T> {}
+impl<'a, T: Types> Hash for SyntaxElement<'a, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            SyntaxElement::Node(it) => it.hash(state),
+            SyntaxElement::Token(it) => it.hash(state),
+        }
+    }
+}
+
+impl<'a, T: Types> From<&'a SyntaxNode<T>> for SyntaxElement<'a, T> {
+    fn from(node: &'a SyntaxNode<T>) -> SyntaxElement<'a, T> {
+        SyntaxElement::Node(node)
+    }
+}
+impl<'a, T: Types> From<SyntaxToken<'a, T>> for SyntaxElement<'a, T> {
+    fn from(token: SyntaxToken<'a, T>) -> SyntaxElement<'a, T> {
+        SyntaxElement::Token(token)
+    }
+}
+
+impl<'a, T: Types> SyntaxElement<'a, T> {
+    /// Kind of this element.
+    pub fn kind(&self) -> T::Kind {
+        match self {
+            SyntaxElement::Node(it) => it.kind(),
+            SyntaxElement::Token(it) => it.kind(),
+        }
+    }
+    /// Text range, covered by this element.
+    pub fn range(&self) -> TextRange {
+        match self {
+            SyntaxElement::Node(it) => it.range(),
+            SyntaxElement::Token(it) => it.range(),
+        }
+    }
+    /// Parent node, containing this element.
+    pub fn parent(&self) -> Option<&'a SyntaxNode<T>> {
+        match self {
+            SyntaxElement::Node(it) => it.parent(),
+            SyntaxElement::Token(it) => Some(it.parent()),
+        }
+    }
+    /// Next sibling, including tokens.
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+        match self {
+            SyntaxElement::Node(it) => it.next_sibling_or_token(),
+            SyntaxElement::Token(it) => it.next_sibling_or_token(),
+        }
+    }
+    /// Next sibling, including tokens.
+    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+        match self {
+            SyntaxElement::Node(it) => it.prev_sibling_or_token(),
+            SyntaxElement::Token(it) => it.prev_sibling_or_token(),
+        }
+    }
+    /// Return the leftmost token in the subtree of this element.
+    pub(crate) fn first_token(&self) -> Option<SyntaxToken<'a, T>> {
+        match self {
+            SyntaxElement::Node(node) => node.first_token(),
+            SyntaxElement::Token(token) => Some(*token),
+        }
+    }
+    /// Return the rightmost token in the subtree of this element.
+    pub(crate) fn last_token(&self) -> Option<SyntaxToken<'a, T>> {
+        match self {
+            SyntaxElement::Node(node) => node.last_token(),
+            SyntaxElement::Token(token) => Some(*token),
+        }
+    }
+}

--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -1,0 +1,207 @@
+use std::{
+    ptr,
+    fmt,
+    hash::{Hash, Hasher},
+};
+
+use crate::{
+    TreeArc, Types, WalkEvent,
+    SyntaxNode, SyntaxToken, SyntaxElement, SyntaxIndex,
+    GreenNode, GreenElement, GreenIndex,
+    TextRange,
+};
+
+// SyntaxNodes have identity equality semantics
+impl<T: Types> PartialEq<SyntaxNode<T>> for SyntaxNode<T> {
+    fn eq(&self, other: &SyntaxNode<T>) -> bool {
+        ptr::eq(self, other)
+    }
+}
+impl<T: Types> Eq for SyntaxNode<T> {}
+impl<T: Types> Hash for SyntaxNode<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (self as *const SyntaxNode<T>).hash(state)
+    }
+}
+
+impl<T: Types> fmt::Debug for SyntaxNode<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{:?}@{:?}", self.kind(), self.range())
+    }
+}
+impl<T: Types> fmt::Display for SyntaxNode<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        self.preorder_with_tokens()
+            .filter_map(|event| match event {
+                WalkEvent::Enter(SyntaxElement::Token(token)) => Some(token.text()),
+                _ => None,
+            })
+            .try_for_each(|it| write!(fmt, "{}", it))
+    }
+}
+
+impl<T: Types> SyntaxNode<T> {
+    /// Creates a new `SyntaxNode`, which becomes the root of the tree.
+    pub fn new(green: GreenNode<T>, data: T::RootData) -> TreeArc<T, SyntaxNode<T>> {
+        Self::new_root(green, data)
+    }
+
+    /// Get root data.
+    pub fn root_data(&self) -> &T::RootData {
+        &self.root().data
+    }
+
+    /// Get the green node for this node
+    pub fn green(&self) -> &GreenNode<T> {
+        &self.green
+    }
+
+    /// Get kind of this node.
+    pub fn kind(&self) -> T::Kind {
+        self.green.kind()
+    }
+
+    /// Get text range, covered by this node.
+    pub fn range(&self) -> TextRange {
+        let start_offset = self.parent_data().map_or(0.into(), |it| it.start_offset);
+        TextRange::offset_len(start_offset, self.green.text_len())
+    }
+
+    /// Get the parent node.
+    pub fn parent(&self) -> Option<&SyntaxNode<T>> {
+        self.parent_impl()
+    }
+
+    /// Get first child, excluding tokens.
+    pub fn first_child(&self) -> Option<&SyntaxNode<T>> {
+        self.get_child(SyntaxIndex(0))
+    }
+
+    /// Get the first, including tokens.
+    pub fn first_child_or_token(&self) -> Option<SyntaxElement<T>> {
+        let res = match self.green().children().first()? {
+            GreenElement::Node(_) => self.first_child()?.into(),
+            GreenElement::Token(_) => SyntaxToken {
+                parent: self,
+                start_offset: self.range().start(),
+                index_in_green: GreenIndex(0),
+                index_in_parent: SyntaxIndex(0),
+            }
+            .into(),
+        };
+        Some(res)
+    }
+
+    /// Get last child, excluding tokens.
+    pub fn last_child(&self) -> Option<&SyntaxNode<T>> {
+        let idx = self.children_len().prev();
+        self.get_child(idx)
+    }
+
+    /// Get last child, including tokens.
+    pub fn last_child_or_token(&self) -> Option<SyntaxElement<T>> {
+        let res = match self.green().children().last()? {
+            GreenElement::Node(_) => self.last_child()?.into(),
+            GreenElement::Token(t) => SyntaxToken {
+                parent: self,
+                start_offset: self.range().end() - t.text_len(),
+                index_in_green: GreenIndex(self.green().children().len() as u32 - 1),
+                index_in_parent: self.children_len(),
+            }
+            .into(),
+        };
+        Some(res)
+    }
+
+    /// Get next sibling, excluding tokens.
+    pub fn next_sibling(&self) -> Option<&SyntaxNode<T>> {
+        let parent = self.parent()?;
+        let next_sibling_idx = self.parent_data()?.index_in_parent.next();
+        parent.get_child(next_sibling_idx)
+    }
+
+    /// Get next sibling, including tokens.
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<T>> {
+        let parent = self.parent()?;
+        let parent_data = self.parent_data()?;
+        let index_in_green = parent_data.index_in_green.next();
+        match parent.green().get_child(index_in_green)? {
+            GreenElement::Node(_) => self.next_sibling().map(SyntaxElement::from),
+            GreenElement::Token(_) => {
+                let token = SyntaxToken {
+                    parent,
+                    start_offset: self.range().end(),
+                    index_in_green,
+                    index_in_parent: parent_data.index_in_parent.next(),
+                };
+                Some(token.into())
+            }
+        }
+    }
+
+    /// Get previous sibling, excluding tokens.
+    pub fn prev_sibling(&self) -> Option<&SyntaxNode<T>> {
+        let parent = self.parent()?;
+        let prev_sibling_idx = self.parent_data()?.index_in_parent.prev();
+        parent.get_child(prev_sibling_idx)
+    }
+
+    /// Get previous sibling, including tokens.
+    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<T>> {
+        let parent = self.parent()?;
+        let parent_data = self.parent_data()?;
+        let index_in_green = parent_data.index_in_green.prev();
+        match parent.green().get_child(index_in_green)? {
+            GreenElement::Node(_) => self.prev_sibling().map(SyntaxElement::from),
+            GreenElement::Token(it) => {
+                let token = SyntaxToken {
+                    parent,
+                    start_offset: self.range().start() - it.text_len(),
+                    index_in_green,
+                    index_in_parent: parent_data.index_in_parent,
+                };
+                Some(token.into())
+            }
+        }
+    }
+
+    /// Return the leftmost token in the subtree of this node
+    pub fn first_token(&self) -> Option<SyntaxToken<T>> {
+        self.first_child_or_token()?.first_token()
+    }
+
+    /// Return the rightmost token in the subtree of this node
+    pub fn last_token(&self) -> Option<SyntaxToken<T>> {
+        self.last_child_or_token()?.last_token()
+    }
+
+    /// Returns a green tree, equal to the green tree this node
+    /// belongs two, except with this node substitute. The complexity
+    /// of operation is proportional to the depth of the tree
+    pub fn replace_with(&self, replacement: GreenNode<T>) -> GreenNode<T> {
+        assert_eq!(self.kind(), replacement.kind());
+        match self.parent() {
+            None => replacement,
+            Some(parent) => {
+                let me = self.parent_data().unwrap().index_in_green;
+                let mut replacement = Some(replacement);
+                let children: Box<[_]> = parent
+                    .green()
+                    .children()
+                    .iter()
+                    .enumerate()
+                    .map(|(i, child)| {
+                        if i as u32 == me.0 {
+                            replacement.take().unwrap().into()
+                        } else {
+                            child.clone()
+                        }
+                    })
+                    .collect();
+                assert!(replacement.is_none());
+                let new_parent = GreenNode::new(parent.kind(), children);
+                parent.replace_with(new_parent)
+            }
+        }
+    }
+}

--- a/src/syntax_token.rs
+++ b/src/syntax_token.rs
@@ -1,0 +1,157 @@
+use std::{fmt, hash::{Hasher, Hash}};
+
+use crate::{
+    Types, TextUnit, SmolStr, TextRange,
+    SyntaxNode, SyntaxElement, SyntaxIndex,
+    GreenToken, GreenNode, GreenElement, GreenIndex,
+};
+
+/// A token (leaf node) in a syntax tree.
+///
+/// A token can't exist in isolation, it is always attached to a parent Node.
+pub struct SyntaxToken<'a, T: Types> {
+    pub(crate) parent: &'a SyntaxNode<T>,
+    pub(crate) start_offset: TextUnit,
+    /// Index of this token in the green node
+    pub(crate) index_in_green: GreenIndex,
+    /// Index of the following SyntaxNode in the parent. 0 for tokens which come
+    /// before the first non-token child.
+    pub(crate) index_in_parent: SyntaxIndex,
+}
+
+impl<'a, T: Types> Clone for SyntaxToken<'a, T> {
+    fn clone(&self) -> SyntaxToken<'a, T> {
+        *self
+    }
+}
+
+impl<'a, T: Types> Copy for SyntaxToken<'a, T> {}
+
+impl<'a, 'b, T: Types> PartialEq<SyntaxToken<'a, T>> for SyntaxToken<'b, T> {
+    fn eq(&self, other: &SyntaxToken<T>) -> bool {
+        (self.parent(), self.index_in_green) == (other.parent(), other.index_in_green)
+    }
+}
+impl<'a, T: Types> Eq for SyntaxToken<'a, T> {}
+impl<'a, T: Types> Hash for SyntaxToken<'a, T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (self.parent(), self.index_in_green).hash(state)
+    }
+}
+
+impl<'a, T: Types> fmt::Debug for SyntaxToken<'a, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "{:?}@{:?}", self.kind(), self.range())
+    }
+}
+impl<'a, T: Types> fmt::Display for SyntaxToken<'a, T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.write_str(self.text())
+    }
+}
+
+impl<'a, T: Types> SyntaxToken<'a, T> {
+    /// Kind of this token.
+    pub fn kind(&self) -> T::Kind {
+        self.green().kind()
+    }
+    /// Text of this token.
+    pub fn text(&self) -> &'a SmolStr {
+        self.green().text()
+    }
+    /// Text range, covered by this token.
+    pub fn range(&self) -> TextRange {
+        TextRange::offset_len(self.start_offset, self.green().text_len())
+    }
+    /// Parent node, containing this token.
+    pub fn parent(&self) -> &'a SyntaxNode<T> {
+        self.parent
+    }
+    /// Next sibling of this tokens, including both nodes and tokens.
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+        let index_in_green = self.index_in_green.next();
+        let green = self.parent().green.get_child(index_in_green)?;
+        let element = match green {
+            GreenElement::Token(_) => {
+                let token = SyntaxToken {
+                    parent: self.parent(),
+                    start_offset: self.start_offset + self.green().text_len(),
+                    index_in_green,
+                    index_in_parent: self.index_in_parent,
+                };
+                token.into()
+            }
+            GreenElement::Node(_) => self.parent().get_child(self.index_in_parent).unwrap().into(),
+        };
+        Some(element)
+    }
+    /// Previous sibling of this tokens, including both nodes and tokens.
+    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+        let index_in_green = self.index_in_green.prev();
+        let green = self.parent().green.get_child(index_in_green)?;
+        let element = match green {
+            GreenElement::Token(it) => {
+                let token = SyntaxToken {
+                    parent: self.parent(),
+                    start_offset: self.start_offset - it.text_len(),
+                    index_in_green,
+                    index_in_parent: self.index_in_parent,
+                };
+                token.into()
+            }
+            GreenElement::Node(_) => {
+                self.parent().get_child(self.index_in_parent.prev()).unwrap().into()
+            }
+        };
+        Some(element)
+    }
+    /// Next token in the file (i.e, not necessary a sibling)
+    pub fn next_token(&self) -> Option<SyntaxToken<'a, T>> {
+        match self.next_sibling_or_token() {
+            Some(element) => element.first_token(),
+            None => self.parent().ancestors().find_map(|it| it.next_sibling_or_token()).and_then(|element| element.first_token())
+        }
+    }
+    /// Previous token in the file (i.e, not necessary a sibling)
+    pub fn prev_token(&self) -> Option<SyntaxToken<'a, T>> {
+        match self.prev_sibling_or_token() {
+            Some(element) => element.last_token(),
+            None => self.parent().ancestors().find_map(|it| it.prev_sibling_or_token()).and_then(|element| element.last_token())
+        }
+    }
+
+    /// Returns a green tree, equal to the green tree this token
+    /// belongs two, except with this token substitute. The complexity
+    /// of operation is proportional to the depth of the tree
+    pub fn replace_with(&self, replacement: GreenToken<T>) -> GreenNode<T> {
+        assert_eq!(self.kind(), replacement.kind());
+        let mut replacement = Some(replacement);
+        let parent = self.parent();
+        let me = self.index_in_green;
+
+        let children: Box<[_]> =
+            parent
+                .green()
+                .children()
+                .iter()
+                .enumerate()
+                .map(|(i, child)| {
+                    if i as u32 == me.0 {
+                        replacement.take().unwrap().into()
+                    } else {
+                        child.clone()
+                    }
+                })
+                .collect();
+        assert!(replacement.is_none());
+        let new_parent = GreenNode::new(parent.kind(), children);
+        parent.replace_with(new_parent)
+    }
+
+    fn green(&self) -> &'a GreenToken<T> {
+        match self.parent.green.get_child(self.index_in_green) {
+            Some(GreenElement::Token(it)) => it,
+            _ => unreachable!(),
+        }
+    }
+}


### PR DESCRIPTION
This PR rewrites the API of rowan once again, to better handle leaf nodes (tokens).

Specifically:

* leaf tokens are now stored inline (no separate allocation) in green nodes, and are not stored in red nodes at all (this should help with memory usage, as tokens tend to occupy more than a half of the tree)
* separate `Token` and `Node` types: one has children, another has text