### PR TITLE
Remove Types type familiy

### DIFF
--- a/src/syntax_element.rs
+++ b/src/syntax_element.rs
@@ -1,60 +1,35 @@
-use std::hash::{Hash, Hasher};
-
-use crate::{Types, SyntaxNode, SyntaxToken, TextRange};
+use crate::{SyntaxNode, SyntaxToken, SyntaxKind, TextRange};
 
 /// Either a SyntaxToken or SyntaxNode.
-#[derive(Debug)]
-pub enum SyntaxElement<'a, T: Types> {
-    Node(&'a SyntaxNode<T>),
-    Token(SyntaxToken<'a, T>),
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SyntaxElement<'a> {
+    /// SyntaxNode
+    Node(&'a SyntaxNode),
+    /// SyntaxToken
+    Token(SyntaxToken<'a>),
 }
-
-impl<'a, T: Types> Clone for SyntaxElement<'a, T> {
-    fn clone(&self) -> SyntaxElement<'a, T> {
-        *self
-    }
-}
-impl<'a, T: Types> Copy for SyntaxElement<'a, T> {}
-
-impl<'a, T: Types> PartialEq<SyntaxElement<'a, T>> for SyntaxElement<'a, T> {
-    fn eq(&self, other: &SyntaxElement<T>) -> bool {
-        match (self, other) {
-            (SyntaxElement::Node(n1), SyntaxElement::Node(n2)) => n1 == n2,
-            (SyntaxElement::Token(t1), SyntaxElement::Token(t2)) => t1 == t2,
-            _ => false,
-        }
-    }
-}
-impl<'a, T: Types> Eq for SyntaxElement<'a, T> {}
-impl<'a, T: Types> Hash for SyntaxElement<'a, T> {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match self {
-            SyntaxElement::Node(it) => it.hash(state),
-            SyntaxElement::Token(it) => it.hash(state),
-        }
-    }
-}
-
-impl<'a, T: Types> From<&'a SyntaxNode<T>> for SyntaxElement<'a, T> {
-    fn from(node: &'a SyntaxNode<T>) -> SyntaxElement<'a, T> {
+impl<'a> From<&'a SyntaxNode> for SyntaxElement<'a> {
+    fn from(node: &'a SyntaxNode) -> SyntaxElement<'a> {
         SyntaxElement::Node(node)
     }
 }
-impl<'a, T: Types> From<SyntaxToken<'a, T>> for SyntaxElement<'a, T> {
-    fn from(token: SyntaxToken<'a, T>) -> SyntaxElement<'a, T> {
+impl<'a> From<SyntaxToken<'a>> for SyntaxElement<'a> {
+    fn from(token: SyntaxToken<'a>) -> SyntaxElement<'a> {
         SyntaxElement::Token(token)
     }
 }
 
-impl<'a, T: Types> SyntaxElement<'a, T> {
+impl<'a> SyntaxElement<'a> {
     /// Kind of this element.
-    pub fn kind(&self) -> T::Kind {
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
         match self {
             SyntaxElement::Node(it) => it.kind(),
             SyntaxElement::Token(it) => it.kind(),
         }
     }
     /// Text range, covered by this element.
+    #[inline]
     pub fn range(&self) -> TextRange {
         match self {
             SyntaxElement::Node(it) => it.range(),
@@ -62,35 +37,40 @@ impl<'a, T: Types> SyntaxElement<'a, T> {
         }
     }
     /// Parent node, containing this element.
-    pub fn parent(&self) -> Option<&'a SyntaxNode<T>> {
+    #[inline]
+    pub fn parent(&self) -> Option<&'a SyntaxNode> {
         match self {
             SyntaxElement::Node(it) => it.parent(),
             SyntaxElement::Token(it) => Some(it.parent()),
         }
     }
     /// Next sibling, including tokens.
-    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+    #[inline]
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<'a>> {
         match self {
             SyntaxElement::Node(it) => it.next_sibling_or_token(),
             SyntaxElement::Token(it) => it.next_sibling_or_token(),
         }
     }
     /// Next sibling, including tokens.
-    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<'a, T>> {
+    #[inline]
+    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<'a>> {
         match self {
             SyntaxElement::Node(it) => it.prev_sibling_or_token(),
             SyntaxElement::Token(it) => it.prev_sibling_or_token(),
         }
     }
     /// Return the leftmost token in the subtree of this element.
-    pub(crate) fn first_token(&self) -> Option<SyntaxToken<'a, T>> {
+    #[inline]
+    pub(crate) fn first_token(&self) -> Option<SyntaxToken<'a>> {
         match self {
             SyntaxElement::Node(node) => node.first_token(),
             SyntaxElement::Token(token) => Some(*token),
         }
     }
     /// Return the rightmost token in the subtree of this element.
-    pub(crate) fn last_token(&self) -> Option<SyntaxToken<'a, T>> {
+    #[inline]
+    pub(crate) fn last_token(&self) -> Option<SyntaxToken<'a>> {
         match self {
             SyntaxElement::Node(node) => node.last_token(),
             SyntaxElement::Token(token) => Some(*token),

--- a/src/syntax_node.rs
+++ b/src/syntax_node.rs
@@ -2,34 +2,37 @@ use std::{
     ptr,
     fmt,
     hash::{Hash, Hasher},
+    any::Any,
 };
 
 use crate::{
-    TreeArc, Types, WalkEvent,
+    TreeArc, WalkEvent, SyntaxKind,
     SyntaxNode, SyntaxToken, SyntaxElement, SyntaxIndex,
     GreenNode, GreenElement, GreenIndex,
     TextRange,
 };
 
 // SyntaxNodes have identity equality semantics
-impl<T: Types> PartialEq<SyntaxNode<T>> for SyntaxNode<T> {
-    fn eq(&self, other: &SyntaxNode<T>) -> bool {
+impl PartialEq<SyntaxNode> for SyntaxNode {
+    #[inline]
+    fn eq(&self, other: &SyntaxNode) -> bool {
         ptr::eq(self, other)
     }
 }
-impl<T: Types> Eq for SyntaxNode<T> {}
-impl<T: Types> Hash for SyntaxNode<T> {
+impl Eq for SyntaxNode {}
+impl Hash for SyntaxNode {
+    #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
-        (self as *const SyntaxNode<T>).hash(state)
+        (self as *const SyntaxNode).hash(state)
     }
 }
 
-impl<T: Types> fmt::Debug for SyntaxNode<T> {
+impl fmt::Debug for SyntaxNode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(fmt, "{:?}@{:?}", self.kind(), self.range())
     }
 }
-impl<T: Types> fmt::Display for SyntaxNode<T> {
+impl fmt::Display for SyntaxNode {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         self.preorder_with_tokens()
             .filter_map(|event| match event {
@@ -40,45 +43,53 @@ impl<T: Types> fmt::Display for SyntaxNode<T> {
     }
 }
 
-impl<T: Types> SyntaxNode<T> {
+impl SyntaxNode {
     /// Creates a new `SyntaxNode`, which becomes the root of the tree.
-    pub fn new(green: GreenNode<T>, data: T::RootData) -> TreeArc<T, SyntaxNode<T>> {
+    #[inline]
+    pub fn new(green: GreenNode, data: Option<Box<Any + Send + Sync>>) -> TreeArc<SyntaxNode> {
         Self::new_root(green, data)
     }
 
     /// Get root data.
-    pub fn root_data(&self) -> &T::RootData {
-        &self.root().data
+    #[inline]
+    pub fn root_data(&self) -> Option<&(dyn Any + Send + Sync)> {
+        self.root().data.as_ref().map(|it| &**it)
     }
 
     /// Get the green node for this node
-    pub fn green(&self) -> &GreenNode<T> {
+    #[inline]
+    pub fn green(&self) -> &GreenNode {
         &self.green
     }
 
     /// Get kind of this node.
-    pub fn kind(&self) -> T::Kind {
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
         self.green.kind()
     }
 
     /// Get text range, covered by this node.
+    #[inline]
     pub fn range(&self) -> TextRange {
         let start_offset = self.parent_data().map_or(0.into(), |it| it.start_offset);
         TextRange::offset_len(start_offset, self.green.text_len())
     }
 
     /// Get the parent node.
-    pub fn parent(&self) -> Option<&SyntaxNode<T>> {
+    #[inline]
+    pub fn parent(&self) -> Option<&SyntaxNode> {
         self.parent_impl()
     }
 
     /// Get first child, excluding tokens.
-    pub fn first_child(&self) -> Option<&SyntaxNode<T>> {
+    #[inline]
+    pub fn first_child(&self) -> Option<&SyntaxNode> {
         self.get_child(SyntaxIndex(0))
     }
 
     /// Get the first, including tokens.
-    pub fn first_child_or_token(&self) -> Option<SyntaxElement<T>> {
+    #[inline]
+    pub fn first_child_or_token(&self) -> Option<SyntaxElement> {
         let res = match self.green().children().first()? {
             GreenElement::Node(_) => self.first_child()?.into(),
             GreenElement::Token(_) => SyntaxToken {
@@ -93,13 +104,14 @@ impl<T: Types> SyntaxNode<T> {
     }
 
     /// Get last child, excluding tokens.
-    pub fn last_child(&self) -> Option<&SyntaxNode<T>> {
+    #[inline]
+    pub fn last_child(&self) -> Option<&SyntaxNode> {
         let idx = self.children_len().prev();
         self.get_child(idx)
     }
 
     /// Get last child, including tokens.
-    pub fn last_child_or_token(&self) -> Option<SyntaxElement<T>> {
+    pub fn last_child_or_token(&self) -> Option<SyntaxElement> {
         let res = match self.green().children().last()? {
             GreenElement::Node(_) => self.last_child()?.into(),
             GreenElement::Token(t) => SyntaxToken {
@@ -114,14 +126,15 @@ impl<T: Types> SyntaxNode<T> {
     }
 
     /// Get next sibling, excluding tokens.
-    pub fn next_sibling(&self) -> Option<&SyntaxNode<T>> {
+    #[inline]
+    pub fn next_sibling(&self) -> Option<&SyntaxNode> {
         let parent = self.parent()?;
         let next_sibling_idx = self.parent_data()?.index_in_parent.next();
         parent.get_child(next_sibling_idx)
     }
 
     /// Get next sibling, including tokens.
-    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<T>> {
+    pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
         let parent = self.parent()?;
         let parent_data = self.parent_data()?;
         let index_in_green = parent_data.index_in_green.next();
@@ -140,14 +153,15 @@ impl<T: Types> SyntaxNode<T> {
     }
 
     /// Get previous sibling, excluding tokens.
-    pub fn prev_sibling(&self) -> Option<&SyntaxNode<T>> {
+    #[inline]
+    pub fn prev_sibling(&self) -> Option<&SyntaxNode> {
         let parent = self.parent()?;
         let prev_sibling_idx = self.parent_data()?.index_in_parent.prev();
         parent.get_child(prev_sibling_idx)
     }
 
     /// Get previous sibling, including tokens.
-    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement<T>> {
+    pub fn prev_sibling_or_token(&self) -> Option<SyntaxElement> {
         let parent = self.parent()?;
         let parent_data = self.parent_data()?;
         let index_in_green = parent_data.index_in_green.prev();
@@ -166,19 +180,21 @@ impl<T: Types> SyntaxNode<T> {
     }
 
     /// Return the leftmost token in the subtree of this node
-    pub fn first_token(&self) -> Option<SyntaxToken<T>> {
+    #[inline]
+    pub fn first_token(&self) -> Option<SyntaxToken> {
         self.first_child_or_token()?.first_token()
     }
 
     /// Return the rightmost token in the subtree of this node
-    pub fn last_token(&self) -> Option<SyntaxToken<T>> {
+    #[inline]
+    pub fn last_token(&self) -> Option<SyntaxToken> {
         self.last_child_or_token()?.last_token()
     }
 
     /// Returns a green tree, equal to the green tree this node
     /// belongs two, except with this node substitute. The complexity
     /// of operation is proportional to the depth of the tree
-    pub fn replace_with(&self, replacement: GreenNode<T>) -> GreenNode<T> {
+    pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
         assert_eq!(self.kind(), replacement.kind());
         match self.parent() {
             None => replacement,


### PR DESCRIPTION
Currently, the tree is parametrized over kind and root data, but this is not really necessary. Kind is basically an integer tag, and we can mark it as such.

Root data indeed needs to be custom, but the tree itself does not use it all all, it only stores the data. So, we can just use `Any` here. Given that the users are expected to wrap API anyway, loss of type-safety does not seem like a big problem. 

I am not 100% sure that this is a good idea, but it seems so!