### PR TITLE
Implement better built-in AST dumping support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod syntax_node;
 mod syntax_token;
 mod syntax_element;
 mod algo;
+mod macros;
 
 use std::fmt;
 use crate::{green::GreenIndex, imp::SyntaxIndex};
@@ -34,11 +35,28 @@ pub use crate::{
     syntax_token::SyntaxToken,
     syntax_element::SyntaxElement,
     algo::{WalkEvent, TokenAtOffset, SyntaxNodeChildren, SyntaxElementChildren},
+    macros::*
 };
 
 /// SyntaxKind is a type tag for each token or node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SyntaxKind(pub u16);
+
+/// Optional trait that enables a pretty name for a SyntaxKind. Most
+/// users should not have to worry about this directly, but rather use
+/// the `syntax!()` macro.
+pub trait SyntaxResolver {
+    /// Returns the name for the SyntaxKind, if defined
+    fn name(kind: SyntaxKind) -> Option<&'static str>;
+}
+impl SyntaxKind {
+    /// Uses the SyntaxResolver trait to look up the name for this
+    /// SyntaxKind
+    pub fn name<T: SyntaxResolver>(self) -> &'static str {
+        T::name(self).expect("the name of this syntax kind is not \
+        available in the given resolver")
+    }
+}
 
 pub use crate::imp::{TransparentNewType, TreeArc};
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,49 @@
+/// Internal macro - Don't use! May change at any time disregarding
+/// semver versioning.
+#[macro_export]
+#[doc(hidden)]
+macro_rules! inner_syntax {
+    (@const start $init:expr; $ident:ident $($remaining:tt)*) => {
+        pub const $ident: $crate::SyntaxKind = $crate::SyntaxKind($init);
+        inner_syntax!(@const start $init+1; $($remaining)*);
+    };
+    (@const start $init:expr;) => {};
+}
+
+/// Generate SyntaxKind constants with automatically defined unique
+/// values and SyntaxResolver implementations. This is the recommended
+/// way to create constants for different syntaxes.
+/// ```rust
+/// use rowan::syntax;
+/// syntax! {
+///     start 0;
+///     resolver TokenResolver;
+///     TOKEN_LEFT_PAREN
+///     TOKEN_RIGHT_PAREN
+///     // ...etc
+/// }
+///
+/// assert_eq!(TOKEN_LEFT_PAREN.0, 0);
+/// assert_eq!(TOKEN_RIGHT_PAREN.0, 1);
+/// assert_eq!(TOKEN_LEFT_PAREN.name::<TokenResolver>(), "TOKEN_LEFT_PAREN");
+/// assert_eq!(TOKEN_RIGHT_PAREN.name::<TokenResolver>(), "TOKEN_RIGHT_PAREN");
+/// ```
+#[macro_export]
+macro_rules! syntax {
+    (start $init:expr; resolver $resolver_name:ident; $($ident:ident)*) => {
+        use $crate::inner_syntax;
+        inner_syntax!(@const start $init; $($ident)*);
+
+        struct $resolver_name;
+        impl $crate::SyntaxResolver for $resolver_name {
+            fn name(val: $crate::SyntaxKind) -> Option<&'static str> {
+                match val {
+                    // Depending on stringify! is bad, but how else can I
+                    // get the identifier name?
+                    $($ident => Some(stringify!($ident)),)*
+                    _ => None
+                }
+            }
+        }
+    };
+}


### PR DESCRIPTION
This should
1. Aid users to actually debug their things
2. Aid unit testing by making it easy to create a dump function with a
   stable output, unlike the default debug function

Thoughts?