### PR TITLE
Update docs

### DIFF
--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -74,13 +74,13 @@ fn parse(text: &str) -> TreeArc<Root> {
     impl Parser {
         fn parse(mut self) -> TreeArc<Root> {
             // Make sure that the root node covers all source
-            self.builder.start_node(ROOT.into());
+            self.builder.start_node(ROOT);
             // Parse a list of S-expressions
             loop {
                 match self.sexp() {
                     SexpRes::Eof => break,
                     SexpRes::RParen => {
-                        self.builder.start_node(ERROR.into());
+                        self.builder.start_node(ERROR);
                         self.errors.push("unmatched `)`".to_string());
                         self.bump(); // be sure to chug along in case of error
                         self.builder.finish_node();
@@ -102,7 +102,7 @@ fn parse(text: &str) -> TreeArc<Root> {
         }
         fn list(&mut self) {
             // Start the list node
-            self.builder.start_node(LIST.into());
+            self.builder.start_node(LIST);
             self.bump(); // '('
             loop {
                 match self.sexp() {
@@ -133,7 +133,7 @@ fn parse(text: &str) -> TreeArc<Root> {
             match t {
                 L_PAREN => self.list(),
                 WORD => {
-                    self.builder.start_node(ATOM.into());
+                    self.builder.start_node(ATOM);
                     self.bump();
                     self.builder.finish_node();
                 }
@@ -144,7 +144,7 @@ fn parse(text: &str) -> TreeArc<Root> {
         }
         fn bump(&mut self) {
             let (kind, text) = self.tokens.pop().unwrap();
-            self.builder.token(kind.into(), text);
+            self.builder.token(kind, text);
         }
         fn current(&self) -> Option<SyntaxKind> {
             self.tokens.last().map(|(kind, _)| *kind)
@@ -211,7 +211,7 @@ macro_rules! ast_node {
         impl $ast {
             #[allow(unused)]
             fn cast(node: &SyntaxNode) -> Option<&Self> {
-                if node.kind() == $kind.into() {
+                if node.kind() == $kind {
                     Some(Self::from_repr(node))
                 } else {
                     None

--- a/src/green.rs
+++ b/src/green.rs
@@ -248,7 +248,7 @@ impl GreenNodeBuilder {
         self.parents.push((kind, checkpoint));
     }
     /// Complete tree building. Make sure that
-    /// `start_internal` and `finish_internal` calls
+    /// `start_node_at` and `finish_node` calls
     /// are paired!
     #[inline]
     pub fn finish(mut self) -> GreenNode {

--- a/src/green.rs
+++ b/src/green.rs
@@ -235,13 +235,13 @@ impl GreenNodeBuilder {
         let Checkpoint(checkpoint) = checkpoint;
         assert!(
             checkpoint <= self.children.len(),
-            "checkpoint no longer valid, was finish_internal called early?"
+            "checkpoint no longer valid, was finish_node called early?"
         );
 
         if let Some(&(_, first_child)) = self.parents.last() {
             assert!(
                 checkpoint >= first_child,
-                "checkpoint no longer valid, was an unmatched start_internal called?"
+                "checkpoint no longer valid, was an unmatched start_node_at called?"
             );
         }
 

--- a/src/green.rs
+++ b/src/green.rs
@@ -201,16 +201,27 @@ impl GreenNodeBuilder {
     }
     /// Prepare for maybe wrapping the next node.
     /// The way wrapping works is that you first of all get a checkpoint,
-    /// then you place all tokens you want to wrap, and then *maybe* call start_internal_at.
+    /// then you place all tokens you want to wrap, and then *maybe* call
+    /// `start_node_at`.
     /// Example:
-    /// ```rust,ignore
+    /// ```rust
+    /// # use rowan::{GreenNodeBuilder, SyntaxKind};
+    /// # const PLUS: SyntaxKind = SyntaxKind(0);
+    /// # const OPERATION: SyntaxKind = SyntaxKind(1);
+    /// # struct Parser;
+    /// # impl Parser {
+    /// #     fn peek(&self) -> Option<SyntaxKind> { None }
+    /// #     fn parse_expr(&mut self) {}
+    /// # }
+    /// # let mut builder = GreenNodeBuilder::new();
+    /// # let mut parser = Parser;
     /// let checkpoint = builder.checkpoint();
-    /// self.parse_expr();
-    /// if self.peek() == Some(Token::Plus) {
+    /// parser.parse_expr();
+    /// if parser.peek() == Some(PLUS) {
     ///   // 1 + 2 = Add(1, 2)
-    ///   builder.start_internal_at(checkpoint, Token::Operation);
-    ///   self.parse_expr();
-    ///   builder.finish_internal();
+    ///   builder.start_node_at(checkpoint, OPERATION);
+    ///   parser.parse_expr();
+    ///   builder.finish_node();
     /// }
     /// ```
     #[inline]


### PR DESCRIPTION
* update docs for `GreenNodeBuilder::checkpoint` and make its code sample into a non-ignored doc test
* update other docs and panic messages that referred to `start_internal` and `finish_internal`
* remove `.into()`s that are no longer needed after the last change to `s_expressions.rs` example