### PR TITLE
Avoid temporary allocation in Serialize implementations

### DIFF
--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,9 +1,27 @@
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use std::fmt;
 
 use crate::{
     api::{Language, SyntaxNode, SyntaxToken},
     NodeOrToken,
 };
+
+struct SerDisplay<T>(T);
+impl<T: fmt::Display> Serialize for SerDisplay<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.collect_str(&self.0)
+    }
+}
+
+struct DisplayDebug<T>(T);
+impl<T: fmt::Debug> fmt::Display for DisplayDebug<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
 
 impl<L: Language> Serialize for SyntaxNode<L> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -11,8 +29,7 @@ impl<L: Language> Serialize for SyntaxNode<L> {
         S: Serializer,
     {
         let mut state = serializer.serialize_map(Some(3))?;
-        //FIXME: use https://github.com/serde-rs/serde/issues/1316 to avoid allocation.
-        state.serialize_entry("kind", format!("{:?}", self.kind()).as_str())?;
+        state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
         state.serialize_entry("text_range", &self.text_range())?;
         state.serialize_entry("children", &Children(self))?;
         state.end()
@@ -25,8 +42,7 @@ impl<L: Language> Serialize for SyntaxToken<L> {
         S: Serializer,
     {
         let mut state = serializer.serialize_map(Some(3))?;
-        //FIXME: use https://github.com/serde-rs/serde/issues/1316 to avoid allocation.
-        state.serialize_entry("kind", format!("{:?}", self.kind()).as_str())?;
+        state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
         state.serialize_entry("text_range", &self.text_range())?;
         state.serialize_entry("text", &self.text().as_str())?;
         state.end()


### PR DESCRIPTION
Fixes these `FIXME`s:

https://github.com/rust-analyzer/rowan/blob/a00ccb60ea99eccbc7f24d31ee83e925e0d8258d/src/serde_impls.rs#L14-L15
https://github.com/rust-analyzer/rowan/blob/a00ccb60ea99eccbc7f24d31ee83e925e0d8258d/src/serde_impls.rs#L28-L29

This necessarily uses two wrapper types: one to delegate to [`Serializer::collect_str`](https://docs.serde.rs/serde/trait.Serializer.html#method.collect_str), and since that uses `Display`, one to implement `Display` by forwarding to `Debug`.

The benefit is that any data format serializer that specializes `collect_str` (such as `serde_json`) will now be able to skip the temporary `String` allocation.