### PR TITLE
Proof of concept: trailing objects for GreenNode

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
     future_incompatible,
     // missing_docs,
 )]
-#![deny(unsafe_code)]
+#![warn(unsafe_code)]
 #![allow(unused)]
 
 mod green;


### PR DESCRIPTION
~~This is "theoretically unsound" as of current as it requires creating a fat pointer from a thin pointer gotten from `alloc`. However, it should have enough paranoia checking to kill performance of `GreenNode::new` and ensure that it doesn't cause UB due to implementation details changing.~~

The "`llvm::trailing_objects` trick" requires that the "`trailing_objects` carrier" always be behind a pointer (as it is `?Sized`). For simplicity of the PoC, I just put an `Arc` inside `GreenNode`, so it's essentially C++ `ptr::shared<GreenNodeInner>`. Because of this we aren't even saving allocations, just moving the syntax kind and text length of the `GreenNode` inside the `Arc`.

This doesn't even give us space savings, as `GreenElement` remains 5 `usize` large, as `GreenToken` is still 4 `usize` large and there is no way to niche `GreenNode` and `GreenToken` together. This does reduce the size of `GreenNode` from 3 `usize` to 2 `usize`, but that benefit just can't proliferate to `GreenElement`.

Because of this I recommend removing the `llvm::trailing_objects` mention or otherwise clarifying how it might benefit the tree.