### PR TITLE
Trailing objects in GreenNode

### DIFF
--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -5,6 +5,8 @@
 //! (+ (* 15 2) 62)
 //! ```
 
+use std::sync::Arc;
+
 /// Currently, rowan doesn't have a hook to add your own interner,
 /// but `SmolStr` should be a "good enough" type for representing
 /// tokens.
@@ -73,7 +75,7 @@ use rowan::GreenNodeBuilder;
 /// which is controlled by the `R` parameter.
 
 struct Parse {
-    green_node: rowan::GreenNode,
+    green_node: Arc<rowan::GreenNode>,
     #[allow(unused)]
     errors: Vec<String>,
 }
@@ -129,7 +131,7 @@ fn parse(text: &str) -> Parse {
             self.builder.finish_node();
 
             // Turn the builder into a complete node.
-            let green: GreenNode = self.builder.finish();
+            let green: Arc<GreenNode> = self.builder.finish();
             // Construct a `SyntaxNode` from `GreenNode`,
             // using errors as the root data.
             Parse { green_node: green, errors: self.errors }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
     cursor, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText, TextRange,
@@ -146,10 +146,10 @@ impl<L: Language> fmt::Display for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-    pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
+    pub fn new_root(green: Arc<GreenNode>) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
-    pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
+    pub fn replace_with(&self, replacement: Arc<GreenNode>) -> Arc<GreenNode> {
         self.raw.replace_with(replacement)
     }
 
@@ -262,7 +262,7 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-    pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
+    pub fn replace_with(&self, new_token: GreenToken) -> Arc<GreenNode> {
         self.raw.replace_with(new_token)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unsafe_code)]
 #![allow(unused)]
 
+#[allow(unsafe_code)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;
@@ -36,23 +37,26 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
-        f::<GreenNode>();
+        f::<Box<GreenNode>>();
     }
 
     #[test]
     fn test_size_of() {
         use std::mem::size_of;
 
-        eprintln!("GreenNode    {}", size_of::<GreenNode>());
-        eprintln!("GreenToken   {}", size_of::<GreenToken>());
-        eprintln!("GreenElement {}", size_of::<GreenElement>());
+        eprintln!("Arc<GreenNode> {}", size_of::<Arc<GreenNode>>());
+        eprintln!("GreenToken     {}", size_of::<GreenToken>());
+        eprintln!("GreenElement   {}", size_of::<GreenElement>());
         eprintln!();
         eprintln!("SyntaxNode    {}", size_of::<cursor::SyntaxNode>());
         eprintln!("SyntaxToken   {}", size_of::<cursor::SyntaxToken>());
         eprintln!("SyntaxElement {}", size_of::<cursor::SyntaxElement>());
+        eprintln!();
+        eprintln!("NodeData {}", size_of::<cursor::NodeData>());
     }
 }


### PR DESCRIPTION
Supersedes #31 by doing it for real this time. In addition, the laundry list of assumptions have been reduced to just alignment of `GreenNode` and offset of `GreenNode` fields, which are tested but not checked at runtime. The one unwritten assumption is that there is no padding after `GreenNode.children`, which I think is indeed guaranteed by `#[repr(C)]`.

I still expect this to be neutral or negative on performance. `GreenNode` used to be `3xusize` and now `Arc<GreenNode>` is `2xusize`, but `GreenElement` is still `5xusize` due to storing the  `4xusize` large `GreenToken` inline. The internal `cursor::NodeData` remains at `5xusize` large as well as `SyntaxNode`, `SyntaxToken`, and `SyntaxElement` remaining unchanged.

Realistically, this removes one pointer chase in `NodeData` to get to the green node's children at the cost of some tricky unsafe allocation. It also adds a pointer chase in `GreenElement` to get to a `GreenNode`'s kind or len.