### PR TITLE
Boxed tokens

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rustc-hash = "1.0.1"
 text_unit = "0.1.6"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
+static_assertions = "1.0.0"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -111,7 +111,7 @@ impl<I: Iterator<Item = (SyntaxKind, SmolStr)>> Parser<I> {
 }
 
 fn print(indent: usize, element: SyntaxElement) {
-    let kind: SyntaxKind = element.kind().into();
+    let kind: SyntaxKind = element.kind();
     print!("{:indent$}", "", indent = indent);
     match element {
         NodeOrToken::Node(node) => {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -60,6 +60,8 @@ type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 /// but doesn't contain offsets and parent pointers.
 use rowan::GreenNode;
 
+use std::sync::Arc;
+
 /// You can construct GreenNodes by hand, but a builder
 /// is helpful for top-down parsers: it maintains a stack
 /// of currently in-progress nodes
@@ -73,7 +75,7 @@ use rowan::GreenNodeBuilder;
 /// which is controlled by the `R` parameter.
 
 struct Parse {
-    green_node: rowan::GreenNode,
+    green_node: Arc<rowan::GreenNode>,
     #[allow(unused)]
     errors: Vec<String>,
 }
@@ -129,7 +131,7 @@ fn parse(text: &str) -> Parse {
             self.builder.finish_node();
 
             // Turn the builder into a complete node.
-            let green: GreenNode = self.builder.finish();
+            let green: Arc<GreenNode> = self.builder.finish();
             // Construct a `SyntaxNode` from `GreenNode`,
             // using errors as the root data.
             Parse { green_node: green, errors: self.errors }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
     cursor, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText, TextRange,
@@ -146,10 +146,10 @@ impl<L: Language> fmt::Display for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-    pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
+    pub fn new_root(green: Arc<GreenNode>) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
-    pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
+    pub fn replace_with(&self, replacement: Arc<GreenNode>) -> Arc<GreenNode> {
         self.raw.replace_with(replacement)
     }
 
@@ -262,7 +262,7 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-    pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
+    pub fn replace_with(&self, new_token: Arc<GreenToken>) -> Arc<GreenNode> {
         self.raw.replace_with(new_token)
     }
 

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 
@@ -5,10 +7,48 @@ use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 #[derive(Clone, Copy, Debug)]
 pub struct Checkpoint(usize);
 
+/// Green nodes are fully immutable, so it's ok to deduplicate them.
+/// This is the same optimization that Roslyn does
+/// https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
+///
+/// For example, all `#[inline]` in this file share the same green node!
+/// For `libsyntax/parse/parser.rs`, measurements show that deduping saves
+/// 17% of the memory for green nodes!
+/// Future work: make hashing faster by avoiding rehashing of subtrees.
+#[derive(Default, Debug)]
+struct Cache {
+    node: rustc_hash::FxHashSet<Arc<GreenNode>>,
+    token: rustc_hash::FxHashSet<Arc<GreenToken>>,
+}
+
+impl Cache {
+    fn node(&mut self, mut node: Arc<GreenNode>) -> Arc<GreenNode> {
+        // In lieu of a more sophisticated cache, we only cache "small" nodes.
+        if node.children().len() <= 3 {
+            match self.node.get(&node) {
+                Some(cached) => node = cached.clone(),
+                None => assert!(self.node.insert(node.clone())),
+            }
+        }
+        node
+    }
+
+    fn token(&mut self, token: GreenToken) -> Arc<GreenToken> {
+        match self.token.get(&token) {
+            Some(token) => token.clone(),
+            None => {
+                let token = Arc::new(token);
+                assert!(self.token.insert(token.clone()));
+                token
+            }
+        }
+    }
+}
+
 /// A builder for a green tree.
 #[derive(Default, Debug)]
 pub struct GreenNodeBuilder {
-    cache: rustc_hash::FxHashSet<GreenNode>,
+    cache: Cache,
     parents: Vec<(SyntaxKind, usize)>,
     children: Vec<GreenElement>,
 }
@@ -19,41 +59,31 @@ impl GreenNodeBuilder {
     pub fn new() -> GreenNodeBuilder {
         GreenNodeBuilder::default()
     }
+
     /// Adds new token to the current branch.
     #[inline]
     pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {
-        let token = GreenToken::new(kind, text);
+        let token = self.cache.token(GreenToken::new(kind, text));
         self.children.push(token.into());
     }
+
     /// Start new node and make it current.
     #[inline]
     pub fn start_node(&mut self, kind: SyntaxKind) {
         let len = self.children.len();
         self.parents.push((kind, len));
     }
+
     /// Finish current branch and restore previous
     /// branch as current.
     #[inline]
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
-        let children: Vec<_> = self.children.drain(first_child..).collect();
-        let mut node = GreenNode::new(kind, children.into_boxed_slice());
-        // Green nodes are fully immutable, so it's ok to deduplicate them.
-        // This is the same optimization that Roslyn does
-        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
-        //
-        // For example, all `#[inline]` in this file share the same green node!
-        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
-        // 17% of the memory for green nodes!
-        // Future work: make hashing faster by avoiding rehashing of subtrees.
-        if node.children().len() <= 3 {
-            match self.cache.get(&node) {
-                Some(existing) => node = existing.clone(),
-                None => assert!(self.cache.insert(node.clone())),
-            }
-        }
+        let children: Box<[_]> = self.children.drain(first_child..).collect();
+        let node = self.cache.node(GreenNode::new(kind, children));
         self.children.push(node.into());
     }
+
     /// Prepare for maybe wrapping the next node.
     /// The way wrapping works is that you first of all get a checkpoint,
     /// then you place all tokens you want to wrap, and then *maybe* call
@@ -83,6 +113,7 @@ impl GreenNodeBuilder {
     pub fn checkpoint(&self) -> Checkpoint {
         Checkpoint(self.children.len())
     }
+
     /// Wrap the previous branch marked by `checkpoint` in a new branch and
     /// make it current.
     #[inline]
@@ -102,11 +133,12 @@ impl GreenNodeBuilder {
 
         self.parents.push((kind, checkpoint));
     }
+
     /// Complete tree building. Make sure that
     /// `start_node_at` and `finish_node` calls
     /// are paired!
     #[inline]
-    pub fn finish(mut self) -> GreenNode {
+    pub fn finish(mut self) -> Arc<GreenNode> {
         assert_eq!(self.children.len(), 1);
         match self.children.pop().unwrap() {
             NodeOrToken::Node(node) => node,

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -79,7 +79,7 @@ impl GreenNodeBuilder {
     #[inline]
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
-        let children: Box<[_]> = self.children.drain(first_child..).collect();
+        let children: Vec<_> = self.children.drain(first_child..).collect();
         let node = self.cache.node(GreenNode::new(kind, children));
         self.children.push(node.into());
     }

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,18 +1,20 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
 
-pub type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+pub type GreenElement = NodeOrToken<Arc<GreenNode>, Arc<GreenToken>>;
 
-impl From<GreenNode> for GreenElement {
+impl From<Arc<GreenNode>> for GreenElement {
     #[inline]
-    fn from(node: GreenNode) -> GreenElement {
+    fn from(node: Arc<GreenNode>) -> GreenElement {
         NodeOrToken::Node(node)
     }
 }
 
-impl From<GreenToken> for GreenElement {
+impl From<Arc<GreenToken>> for GreenElement {
     #[inline]
-    fn from(token: GreenToken) -> GreenElement {
+    fn from(token: Arc<GreenToken>) -> GreenElement {
         NodeOrToken::Token(token)
     }
 }
@@ -26,6 +28,7 @@ impl GreenElement {
             NodeOrToken::Token(it) => it.kind(),
         }
     }
+
     /// Returns length of the text covered by this element.
     #[inline]
     pub fn text_len(&self) -> TextUnit {

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,0 +1,37 @@
+use super::*;
+use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
+
+pub type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+
+impl From<GreenNode> for GreenElement {
+    #[inline]
+    fn from(node: GreenNode) -> GreenElement {
+        NodeOrToken::Node(node)
+    }
+}
+
+impl From<GreenToken> for GreenElement {
+    #[inline]
+    fn from(token: GreenToken) -> GreenElement {
+        NodeOrToken::Token(token)
+    }
+}
+
+impl GreenElement {
+    /// Returns kind of this element.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        match self {
+            NodeOrToken::Node(it) => it.kind(),
+            NodeOrToken::Token(it) => it.kind(),
+        }
+    }
+    /// Returns length of the text covered by this element.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        match self {
+            NodeOrToken::Node(it) => it.text_len(),
+            NodeOrToken::Token(it) => it.text_len(),
+        }
+    }
+}

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -1,0 +1,6 @@
+mod node;
+mod token;
+mod element;
+mod builder;
+
+pub use self::{builder::*, element::GreenElement, node::GreenNode, token::GreenToken};

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,37 +1,143 @@
-use std::sync::Arc;
+use static_assertions::*;
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    mem, ptr, slice,
+    sync::Arc,
+};
 
 use super::*;
 use crate::{cursor::SyntaxKind, TextUnit};
+use std::alloc::handle_alloc_error;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct GreenNodeHead {
+    kind: SyntaxKind,
+    text_len: TextUnit,
+}
+
+assert_eq_size!(GreenNodeHead, u64);
+assert_eq_align!(GreenNodeHead, u32);
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct GreenNode {
-    kind: SyntaxKind,
-    text_len: TextUnit,
-    //TODO: implement llvm::trailing_objects trick
-    children: Arc<[GreenElement]>,
+    head: GreenNodeHead,
+    children: [GreenElement],
+}
+
+#[test]
+fn node_layout() {
+    let node = unsafe { GreenNode::dummy() };
+    assert_eq!(GreenNode::align(), mem::align_of_val(node));
+    assert_eq!(GreenNode::size_for(0), mem::size_of_val(node));
+    assert_eq!(GreenNode::layout_for(0), Layout::for_value(node));
+    assert_eq!(
+        GreenNode::offset_of_head(),
+        &node.head as *const _ as *const () as isize - node as *const _ as *const () as isize
+    );
+    assert_eq!(
+        GreenNode::offset_of_children(),
+        &node.children as *const _ as *const () as isize - node as *const _ as *const () as isize
+    );
 }
 
 impl GreenNode {
+    #[inline]
+    fn alloc<I>(kind: SyntaxKind, text_len: TextUnit, children: I) -> Arc<GreenNode>
+    where
+        I: Iterator<Item = GreenElement> + ExactSizeIterator,
+    {
+        let len = children.len();
+        let head = GreenNodeHead { kind, text_len };
+        let layout = GreenNode::layout_for(len);
+
+        let boxed = unsafe {
+            let ptr = ptr::NonNull::new(alloc(layout))
+                .unwrap_or_else(|| handle_alloc_error(layout))
+                .as_ptr();
+
+            ptr::write(ptr.offset(GreenNode::offset_of_head()).cast(), head);
+
+            let mut fam = ptr.offset(GreenNode::offset_of_children()).cast::<GreenElement>();
+            for child in children {
+                ptr::write(fam, child);
+                fam = fam.offset(1);
+            }
+
+            let ptr: *mut [u8] = slice::from_raw_parts_mut(ptr, len);
+            Box::from_raw(ptr as *mut GreenNode)
+        };
+
+        // NB: this creates a new allocation for the Arc, moves into it, and drops the Box.
+        // We cannot allocate an Arc directly, so it's this or implementing a custom Arc.
+        boxed.into()
+    }
+
+    const fn align() -> usize {
+        let head_align = mem::align_of::<GreenNodeHead>();
+        let tail_align = mem::align_of::<GreenElement>();
+        [head_align, tail_align][(head_align < tail_align) as usize] // true == 1usize
+    }
+
+    const fn size_for(child_count: usize) -> usize {
+        let head_size = mem::size_of::<GreenNodeHead>();
+        let tail_align = mem::align_of::<GreenElement>();
+        let tail_size = mem::size_of::<GreenElement>() * child_count;
+        head_size + head_size % tail_align + tail_size + tail_size % GreenNode::align()
+        // head ^   ^^^^^^^ padding ^^^^^^   ^^ tail ^   ^^^^^^^^^^^ padding ^^^^^^^^^^
+    }
+
+    const fn layout_for(child_count: usize) -> Layout {
+        unsafe {
+            Layout::from_size_align_unchecked(GreenNode::size_for(child_count), GreenNode::align())
+        }
+    }
+
+    const fn offset_of_head() -> isize {
+        0
+    }
+
+    const fn offset_of_children() -> isize {
+        let head_size = mem::size_of::<GreenNodeHead>() as isize;
+        let tail_align = mem::align_of::<GreenElement>() as isize;
+        GreenNode::offset_of_head() + head_size + head_size % tail_align
+    }
+}
+
+impl GreenNode {
+    /// A dummy `GreenNode` for use as a placeholder.
+    ///
+    /// # Safety
+    ///
+    /// You _can not_ upgrade this reference to `Arc`.
+    /// It is a fully valid `GreenNode` otherwise.
+    pub(crate) unsafe fn dummy() -> &'static GreenNode {
+        static HEAD: u64 = 0;
+        // produce a `mem::zeroed` GreenNodeHead with no children
+        &*(slice::from_raw_parts(&HEAD, 0) as *const [u64] as *const GreenNode)
+    }
+
     /// Creates new Node.
     #[inline]
-    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> Arc<GreenNode> {
+    pub fn new(kind: SyntaxKind, children: Vec<GreenElement>) -> Arc<GreenNode> {
         let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        Arc::new(GreenNode { kind, text_len, children: children.into() })
+        GreenNode::alloc(kind, text_len, children.into_iter())
     }
 
     /// Kind of this node.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.kind
+        self.head.kind
     }
 
     /// Length of the text, covered by this node.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        self.text_len
+        self.head.text_len
     }
+
     /// Children of this node.
     #[inline]
     pub fn children(&self) -> &[GreenElement] {

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -16,9 +16,9 @@ pub struct GreenNode {
 impl GreenNode {
     /// Creates new Node.
     #[inline]
-    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> Arc<GreenNode> {
         let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        GreenNode { kind, text_len, children: children.into() }
+        Arc::new(GreenNode { kind, text_len, children: children.into() })
     }
 
     /// Kind of this node.

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -144,3 +144,18 @@ impl GreenNode {
         &self.children
     }
 }
+
+impl ToOwned for GreenNode {
+    type Owned = Arc<GreenNode>;
+
+    fn to_owned(&self) -> Self::Owned {
+        unsafe {
+            // This is safe because all `GreenNode`s live behind an `Arc`.
+            let arc = Arc::from_raw(self);
+            // NB: The real owning `Arc` cannot be dropped here because it is borrowed.
+            // Don't forget to increase the reference count!
+            mem::forget(arc.clone());
+            arc
+        }
+    }
+}

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::{cursor::SyntaxKind, TextUnit};
+
+/// Internal node in the immutable tree.
+/// It has other nodes and tokens as children.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GreenNode {
+    kind: SyntaxKind,
+    text_len: TextUnit,
+    //TODO: implement llvm::trailing_objects trick
+    children: Arc<[GreenElement]>,
+}
+
+impl GreenNode {
+    /// Creates new Node.
+    #[inline]
+    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+        let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
+        GreenNode { kind, text_len, children: children.into() }
+    }
+
+    /// Kind of this node.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
+    }
+
+    /// Length of the text, covered by this node.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        self.text_len
+    }
+    /// Children of this node.
+    #[inline]
+    pub fn children(&self) -> &[GreenElement] {
+        &self.children
+    }
+}

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,0 +1,31 @@
+use crate::{cursor::SyntaxKind, SmolStr, TextUnit};
+
+/// Leaf node in the immutable tree.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GreenToken {
+    kind: SyntaxKind,
+    text: SmolStr,
+}
+
+impl GreenToken {
+    /// Creates new Token.
+    #[inline]
+    pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
+        GreenToken { kind, text }
+    }
+    /// Kind of this Token.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
+    }
+    /// Text of this Token.
+    #[inline]
+    pub fn text(&self) -> &SmolStr {
+        &self.text
+    }
+    /// Text of this Token.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        TextUnit::from_usize(self.text.len())
+    }
+}

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -13,16 +13,19 @@ impl GreenToken {
     pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
         GreenToken { kind, text }
     }
+
     /// Kind of this Token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
         self.kind
     }
+
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &SmolStr {
         &self.text
     }
+
     /// Text of this Token.
     #[inline]
     pub fn text_len(&self) -> TextUnit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,7 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
-#![allow(unused)]
 
-#[warn(unused)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unsafe_code)]
 #![allow(unused)]
 
+#[warn(unused)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
+#![allow(unused)]
 
+#[allow(unsafe_code)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;
@@ -35,20 +37,22 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
-        f::<GreenNode>();
+        f::<Arc<GreenNode>>();
     }
 
     #[test]
     fn test_size_of() {
         use std::mem::size_of;
 
-        eprintln!("GreenNode    {}", size_of::<GreenNode>());
-        eprintln!("GreenToken   {}", size_of::<GreenToken>());
-        eprintln!("GreenElement {}", size_of::<GreenElement>());
+        eprintln!("GreenToken      {}", size_of::<GreenToken>());
+        eprintln!("Arc<GreenNode>  {}", size_of::<Arc<GreenNode>>());
+        eprintln!("Arc<GreenToken> {}", size_of::<Arc<GreenToken>>());
+        eprintln!("GreenElement    {}", size_of::<GreenElement>());
         eprintln!();
         eprintln!("SyntaxNode    {}", size_of::<cursor::SyntaxNode>());
         eprintln!("SyntaxToken   {}", size_of::<cursor::SyntaxToken>());

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -1,8 +1,8 @@
-use std::{fmt, ops};
+use std::fmt;
 
 use crate::{
-    cursor::{SyntaxElement, SyntaxNode, SyntaxToken},
-    NodeOrToken, SmolStr, TextRange, TextUnit,
+    cursor::{SyntaxNode, SyntaxToken},
+    TextRange, TextUnit,
 };
 
 #[derive(Clone)]
@@ -43,7 +43,6 @@ impl SyntaxText {
     }
 
     pub fn char_at(&self, offset: TextUnit) -> Option<char> {
-        let offset = offset.into();
         let mut start: TextUnit = 0.into();
         let res = self.try_for_each_chunk(|chunk| {
             let end = start + TextUnit::of_str(chunk);
@@ -59,7 +58,7 @@ impl SyntaxText {
 
     pub fn slice<R: private::SyntaxTextRange>(&self, range: R) -> SyntaxText {
         let start = range.start().unwrap_or_default();
-        let end = range.end().unwrap_or(self.len());
+        let end = range.end().unwrap_or_else(|| self.len());
         assert!(start <= end);
         let len = end - start;
         let start = self.range.start() + start;
@@ -97,6 +96,7 @@ impl SyntaxText {
 
     pub fn for_each_chunk<F: FnMut(&str)>(&self, mut f: F) {
         enum Void {}
+        #[allow(clippy::unit_arg)]
         match self.try_for_each_chunk(|chunk| Ok::<(), Void>(f(chunk))) {
             Ok(()) => (),
             Err(void) => match void {},
@@ -191,7 +191,6 @@ fn zip_texts<I: Iterator<Item = (SyntaxToken, TextRange)>>(xs: &mut I, ys: &mut 
         x.1 = TextRange::from_to(x.1.start(), x.1.len() - advance);
         y.1 = TextRange::from_to(y.1.start(), y.1.len() - advance);
     }
-    None
 }
 
 impl Eq for SyntaxText {}

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,7 +1,3 @@
-use std::{iter, ops::Range};
-
-use crate::{TextRange, TextUnit};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
     Node(N),


### PR DESCRIPTION
This is the result of applying [this technique](https://github.com/rust-analyzer/rowan/pull/32#issuecomment-548603444) of boxing/deduping `GreenToken` to compress `GreenElement` and, as a result, the allocation for a `GreenNode`'s children. It also applies a minimal flexible array member technique for the `GreenNode`'s children, allocating them inline.

This is as far as the technique can go with using the standard `Arc` and `NodeOrToken`. `GreenElement = NodeOrToken<Arc<GreenNode>, Arc<GreenToken>>` is 3x`usize` large, but [can theoretically be niched to 2x`usize`](https://github.com/rust-lang/rust/issues/66029). (NB: the same niche optimization can be applied to `SyntaxElement`.)

I've split this PR up into commits each representing a logical step.

```
GreenToken      32
Arc<GreenNode>  16
Arc<GreenToken> 8
GreenElement    24

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```

It is possible to optimize size further, but I'd like to propose those in a second PR on top of this one. Remaining potential optimization steps along these lines:

- Implement a specific `GreenElement` to manually niche `Arc<GreenNode>` and `Arc<GreenToken>`.
    - [Could be done by the compiler.](https://github.com/rust-lang/rust/issues/66029) `sizeof(GreenElement)` = 2x`usize`.
- Implement a specific `SyntaxElement` to manually niche `SyntaxNode` and `SyntaxToken`.
    - [Could be done by the compiler.](https://github.com/rust-lang/rust/issues/66029) `sizeof(SyntaxElement)` = 2x`usize`.
- Implement a specific `Arc<GreenNode>` to make ptr-to-`GreenNode` a thin ptr instead of a fat ptr.
    - Standard `GreenElement = NodeOrToken` would be 2x`usize`. Manually non-zero-cost niched `GreenElement` (tag in alignment bits) would be 1x`usize`.

Results in rust-analyzer:

<details><summary>With this branch</summary>

```powershell
PS D:\usr\Documents\Code\Rust\rust-analyzer> cargo run --bin ra_cli --release -- analysis-stats .
    Finished release [optimized + debuginfo] target(s) in 0.46s
     Running `target\release\ra_cli.exe analysis-stats .`
Database loaded, 221 roots, 1.0601376s
Crates in this dir: 27
Total modules found: 331
Total declarations: 11135
Total functions: 3839
Item Collection: 11.8499283s, 0b allocated 0b resident
Total expressions: 89244
Expressions of unknown type: 6960 (7%)
Expressions of partially unknown type: 3522 (3%)
Type mismatches: 3568
Inference: 36.3460289s, 0b allocated 0b resident
Total: 48.1964408s, 0b allocated 0b resident
PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- symbols }
    Finished release [optimized + debuginfo] target(s) in 0.45s


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 738
Ticks             : 7380228
TotalDays         : 8.54193055555555E-06
TotalHours        : 0.000205006333333333
TotalMinutes      : 0.01230038
TotalSeconds      : 0.7380228
TotalMilliseconds : 738.0228



PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- parse --no-dump } 
    Finished release [optimized + debuginfo] target(s) in 0.44s
     Running `target\release\ra_cli.exe parse --no-dump`


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 603
Ticks             : 6035426
TotalDays         : 6.98544675925926E-06
TotalHours        : 0.000167650722222222
TotalMinutes      : 0.0100590433333333
TotalSeconds      : 0.6035426
TotalMilliseconds : 603.5426



```
</details>

<details><summary>Without this branch (<a href="https://github.com/rust-analyzer/rust-analyzer/commit/5451bfb9">5451bfb9</a>)</summary>

```powershell
PS D:\usr\Documents\Code\Rust\rust-analyzer> cargo run --bin ra_cli --release -- analysis-stats .
    Finished release [optimized + debuginfo] target(s) in 0.45s
     Running `target\release\ra_cli.exe analysis-stats .`
Database loaded, 220 roots, 1.0174838s
Crates in this dir: 27
Total modules found: 331
Total declarations: 11135
Total functions: 3839
Item Collection: 10.509602s, 0b allocated 0b resident
Total expressions: 89241                                                                                                                                                 
Expressions of unknown type: 6959 (7%)
Expressions of partially unknown type: 3522 (3%)
Type mismatches: 3569
Inference: 34.963529s, 0b allocated 0b resident
Total: 45.4737377s, 0b allocated 0b resident
PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- symbols }         
    Finished release [optimized + debuginfo] target(s) in 0.44s


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 587
Ticks             : 5875475
TotalDays         : 6.80031828703704E-06
TotalHours        : 0.000163207638888889
TotalMinutes      : 0.00979245833333333
TotalSeconds      : 0.5875475
TotalMilliseconds : 587.5475



PS D:\usr\Documents\Code\Rust\rust-analyzer> Measure-Command { type "D:\rust-lang\src\libcore\unicode\tables.rs" | cargo run --bin ra_cli --release -- parse --no-dump } 
    Finished release [optimized + debuginfo] target(s) in 0.44s
     Running `target\release\ra_cli.exe parse --no-dump`


Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 573
Ticks             : 5737453
TotalDays         : 6.64057060185185E-06
TotalHours        : 0.000159373694444444
TotalMinutes      : 0.00956242166666667
TotalSeconds      : 0.5737453
TotalMilliseconds : 573.7453



```
</details>

I can't test allocation pressure on Windows. The way this is right here, it looks like a consistent loss.