### PR TITLE
Custom GreenElement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ rustc-hash = "1.0.1"
 text_unit = "0.1.6"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
-static_assertions = "1.0.0"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rustc-hash = "1.0.1"
 text_unit = "0.1.6"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
+thin-dst = "1.0.0-beta.4"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rustc-hash = "1.0.1"
 text_unit = "0.1.6"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
+static_assertions = "1.0.0"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -106,7 +106,7 @@ impl<I: Iterator<Item = (SyntaxKind, SmolStr)>> Parser<I> {
         self.parse_add();
         self.builder.finish_node();
 
-        SyntaxNode::new_root(self.builder.finish())
+        SyntaxNode::new_root(self.builder.finish().unwrap_node())
     }
 }
 

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -111,7 +111,7 @@ impl<I: Iterator<Item = (SyntaxKind, SmolStr)>> Parser<I> {
 }
 
 fn print(indent: usize, element: SyntaxElement) {
-    let kind: SyntaxKind = element.kind().into();
+    let kind: SyntaxKind = element.kind();
     print!("{:indent$}", "", indent = indent);
     match element {
         NodeOrToken::Node(node) => {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -58,7 +58,8 @@ type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 
 /// GreenNode is an immutable tree, which is cheap to change,
 /// but doesn't contain offsets and parent pointers.
-use rowan::ArcGreenNode;
+use rowan::GreenNode;
+use std::sync::Arc;
 
 /// You can construct GreenNodes by hand, but a builder
 /// is helpful for top-down parsers: it maintains a stack
@@ -73,7 +74,7 @@ use rowan::GreenNodeBuilder;
 /// which is controlled by the `R` parameter.
 
 struct Parse {
-    green_node: ArcGreenNode,
+    green_node: Arc<GreenNode>,
     #[allow(unused)]
     errors: Vec<String>,
 }
@@ -129,7 +130,7 @@ fn parse(text: &str) -> Parse {
             self.builder.finish_node();
 
             // Turn the builder into a complete node.
-            let green: ArcGreenNode = self.builder.finish().unwrap_node();
+            let green: Arc<GreenNode> = self.builder.finish().unwrap_node();
             // Construct a `SyntaxNode` from `GreenNode`,
             // using errors as the root data.
             Parse { green_node: green, errors: self.errors }

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -60,6 +60,8 @@ type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 /// but doesn't contain offsets and parent pointers.
 use rowan::GreenNode;
 
+use std::sync::Arc;
+
 /// You can construct GreenNodes by hand, but a builder
 /// is helpful for top-down parsers: it maintains a stack
 /// of currently in-progress nodes
@@ -73,7 +75,7 @@ use rowan::GreenNodeBuilder;
 /// which is controlled by the `R` parameter.
 
 struct Parse {
-    green_node: rowan::GreenNode,
+    green_node: Arc<rowan::GreenNode>,
     #[allow(unused)]
     errors: Vec<String>,
 }
@@ -129,7 +131,7 @@ fn parse(text: &str) -> Parse {
             self.builder.finish_node();
 
             // Turn the builder into a complete node.
-            let green: GreenNode = self.builder.finish();
+            let green: Arc<GreenNode> = self.builder.finish();
             // Construct a `SyntaxNode` from `GreenNode`,
             // using errors as the root data.
             Parse { green_node: green, errors: self.errors }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
-    cursor, ArcGreenNode, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText,
-    TextRange, TextUnit, TokenAtOffset, WalkEvent,
+    cursor, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText, TextRange,
+    TextUnit, TokenAtOffset, WalkEvent,
 };
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -146,10 +146,10 @@ impl<L: Language> fmt::Display for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-    pub fn new_root(green: ArcGreenNode) -> SyntaxNode<L> {
+    pub fn new_root(green: Arc<GreenNode>) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
-    pub fn replace_with(&self, replacement: ArcGreenNode) -> ArcGreenNode {
+    pub fn replace_with(&self, replacement: Arc<GreenNode>) -> Arc<GreenNode> {
         self.raw.replace_with(replacement)
     }
 
@@ -262,7 +262,7 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-    pub fn replace_with(&self, new_token: GreenToken) -> ArcGreenNode {
+    pub fn replace_with(&self, new_token: GreenToken) -> Arc<GreenNode> {
         self.raw.replace_with(new_token)
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use std::{fmt, marker::PhantomData};
+use std::{fmt, marker::PhantomData, sync::Arc};
 
 use crate::{
     cursor, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText, TextRange,
@@ -146,10 +146,10 @@ impl<L: Language> fmt::Display for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-    pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
+    pub fn new_root(green: Arc<GreenNode>) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
-    pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
+    pub fn replace_with(&self, replacement: Arc<GreenNode>) -> Arc<GreenNode> {
         self.raw.replace_with(replacement)
     }
 
@@ -262,7 +262,7 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-    pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
+    pub fn replace_with(&self, new_token: Arc<GreenToken>) -> Arc<GreenNode> {
         self.raw.replace_with(new_token)
     }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
-use std::{fmt, marker::PhantomData, sync::Arc};
+use std::{fmt, marker::PhantomData};
 
 use crate::{
-    cursor, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText, TextRange,
-    TextUnit, TokenAtOffset, WalkEvent,
+    cursor, ArcGreenNode, Direction, GreenNode, GreenToken, NodeOrToken, SmolStr, SyntaxText,
+    TextRange, TextUnit, TokenAtOffset, WalkEvent,
 };
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -146,10 +146,10 @@ impl<L: Language> fmt::Display for SyntaxElement<L> {
 }
 
 impl<L: Language> SyntaxNode<L> {
-    pub fn new_root(green: Arc<GreenNode>) -> SyntaxNode<L> {
+    pub fn new_root(green: ArcGreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
-    pub fn replace_with(&self, replacement: Arc<GreenNode>) -> Arc<GreenNode> {
+    pub fn replace_with(&self, replacement: ArcGreenNode) -> ArcGreenNode {
         self.raw.replace_with(replacement)
     }
 
@@ -262,7 +262,7 @@ impl<L: Language> SyntaxNode<L> {
 }
 
 impl<L: Language> SyntaxToken<L> {
-    pub fn replace_with(&self, new_token: Arc<GreenToken>) -> Arc<GreenNode> {
+    pub fn replace_with(&self, new_token: GreenToken) -> ArcGreenNode {
         self.raw.replace_with(new_token)
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -725,7 +725,7 @@ impl Iter {
         Iter { parent, green, offset, index: 0 }
     }
 
-    fn next(&mut self) -> Option<((&GreenElement, u32, TextUnit))> {
+    fn next(&mut self) -> Option<(&GreenElement, u32, TextUnit)> {
         self.green.next().map(|element| {
             let offset = self.offset;
             let index = self.index;

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,9 +1,8 @@
-use std::{mem, sync::Arc};
-
-use super::*;
-use crate::green::node::GreenNodeHead;
-use crate::{cursor::SyntaxKind, SmolStr};
-use thin_dst::{ThinArc, ThinData};
+use {
+    super::*,
+    crate::{cursor::SyntaxKind, SmolStr},
+    std::sync::Arc,
+};
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]
@@ -26,9 +25,7 @@ struct Cache {
 impl Cache {
     fn node(&mut self, node: Arc<GreenNode>) -> ArcGreenNode {
         // In lieu of a more sophisticated cache, we only cache "small" nodes.
-        let node: Arc<ThinData<GreenNodeHead, GreenElement>> = unsafe { mem::transmute(node) };
-        let node: ThinArc<GreenNodeHead, GreenElement> = node.into();
-        let mut node: ArcGreenNode = unsafe { mem::transmute(node) };
+        let mut node = ArcGreenNode::from_fat(node);
         if node.children().len() <= 3 {
             match self.node.get(&node) {
                 Some(cached) => node = cached.clone(),

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 
@@ -5,10 +7,48 @@ use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 #[derive(Clone, Copy, Debug)]
 pub struct Checkpoint(usize);
 
+/// Green nodes are fully immutable, so it's ok to deduplicate them.
+/// This is the same optimization that Roslyn does
+/// https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
+///
+/// For example, all `#[inline]` in this file share the same green node!
+/// For `libsyntax/parse/parser.rs`, measurements show that deduping saves
+/// 17% of the memory for green nodes!
+/// Future work: make hashing faster by avoiding rehashing of subtrees.
+#[derive(Default, Debug)]
+struct Cache {
+    node: rustc_hash::FxHashSet<Arc<GreenNode>>,
+    token: rustc_hash::FxHashSet<Arc<GreenToken>>,
+}
+
+impl Cache {
+    fn node(&mut self, mut node: Arc<GreenNode>) -> Arc<GreenNode> {
+        // In lieu of a more sophisticated cache, we only cache "small" nodes.
+        if node.children().len() <= 3 {
+            match self.node.get(&node) {
+                Some(cached) => node = cached.clone(),
+                None => assert!(self.node.insert(node.clone())),
+            }
+        }
+        node
+    }
+
+    fn token(&mut self, token: GreenToken) -> Arc<GreenToken> {
+        match self.token.get(&token) {
+            Some(token) => token.clone(),
+            None => {
+                let token = Arc::new(token);
+                assert!(self.token.insert(token.clone()));
+                token
+            }
+        }
+    }
+}
+
 /// A builder for a green tree.
 #[derive(Default, Debug)]
 pub struct GreenNodeBuilder {
-    cache: rustc_hash::FxHashSet<GreenNode>,
+    cache: Cache,
     parents: Vec<(SyntaxKind, usize)>,
     children: Vec<GreenElement>,
 }
@@ -19,41 +59,31 @@ impl GreenNodeBuilder {
     pub fn new() -> GreenNodeBuilder {
         GreenNodeBuilder::default()
     }
+
     /// Adds new token to the current branch.
     #[inline]
     pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {
-        let token = GreenToken::new(kind, text);
+        let token = self.cache.token(GreenToken::new(kind, text));
         self.children.push(token.into());
     }
+
     /// Start new node and make it current.
     #[inline]
     pub fn start_node(&mut self, kind: SyntaxKind) {
         let len = self.children.len();
         self.parents.push((kind, len));
     }
+
     /// Finish current branch and restore previous
     /// branch as current.
     #[inline]
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
-        let children: Vec<_> = self.children.drain(first_child..).collect();
-        let mut node = GreenNode::new(kind, children.into_boxed_slice());
-        // Green nodes are fully immutable, so it's ok to deduplicate them.
-        // This is the same optimization that Roslyn does
-        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
-        //
-        // For example, all `#[inline]` in this file share the same green node!
-        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
-        // 17% of the memory for green nodes!
-        // Future work: make hashing faster by avoiding rehashing of subtrees.
-        if node.children().len() <= 3 {
-            match self.cache.get(&node) {
-                Some(existing) => node = existing.clone(),
-                None => assert!(self.cache.insert(node.clone())),
-            }
-        }
+        let children: Box<[_]> = self.children.drain(first_child..).collect();
+        let node = self.cache.node(GreenNode::new(kind, children));
         self.children.push(node.into());
     }
+
     /// Prepare for maybe wrapping the next node.
     /// The way wrapping works is that you first of all get a checkpoint,
     /// then you place all tokens you want to wrap, and then *maybe* call
@@ -83,6 +113,7 @@ impl GreenNodeBuilder {
     pub fn checkpoint(&self) -> Checkpoint {
         Checkpoint(self.children.len())
     }
+
     /// Wrap the previous branch marked by `checkpoint` in a new branch and
     /// make it current.
     #[inline]
@@ -102,11 +133,12 @@ impl GreenNodeBuilder {
 
         self.parents.push((kind, checkpoint));
     }
+
     /// Complete tree building. Make sure that
     /// `start_node_at` and `finish_node` calls
     /// are paired!
     #[inline]
-    pub fn finish(mut self) -> GreenNode {
+    pub fn finish(mut self) -> Arc<GreenNode> {
         assert_eq!(self.children.len(), 1);
         match self.children.pop().unwrap() {
             NodeOrToken::Node(node) => node,

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::*;
-use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
+use crate::{cursor::SyntaxKind, SmolStr};
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]
@@ -17,12 +17,12 @@ pub struct Checkpoint(usize);
 /// Future work: make hashing faster by avoiding rehashing of subtrees.
 #[derive(Default, Debug)]
 struct Cache {
-    node: rustc_hash::FxHashSet<Arc<GreenNode>>,
+    node: rustc_hash::FxHashSet<ArcGreenNode>,
     token: rustc_hash::FxHashSet<Arc<GreenToken>>,
 }
 
 impl Cache {
-    fn node(&mut self, mut node: Arc<GreenNode>) -> Arc<GreenNode> {
+    fn node(&mut self, mut node: ArcGreenNode) -> ArcGreenNode {
         // In lieu of a more sophisticated cache, we only cache "small" nodes.
         if node.children().len() <= 3 {
             match self.node.get(&node) {
@@ -138,11 +138,8 @@ impl GreenNodeBuilder {
     /// `start_node_at` and `finish_node` calls
     /// are paired!
     #[inline]
-    pub fn finish(mut self) -> Arc<GreenNode> {
+    pub fn finish(mut self) -> GreenElement {
         assert_eq!(self.children.len(), 1);
-        match self.children.pop().unwrap() {
-            NodeOrToken::Node(node) => node,
-            NodeOrToken::Token(_) => panic!(),
-        }
+        self.children.pop().unwrap()
     }
 }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -79,7 +79,7 @@ impl GreenNodeBuilder {
     #[inline]
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
-        let children: Box<[_]> = self.children.drain(first_child..).collect();
+        let children: Vec<_> = self.children.drain(first_child..).collect();
         let node = self.cache.node(GreenNode::new(kind, children));
         self.children.push(node.into());
     }

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,18 +1,20 @@
+use std::sync::Arc;
+
 use super::*;
 use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
 
-pub type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+pub type GreenElement = NodeOrToken<Arc<GreenNode>, Arc<GreenToken>>;
 
-impl From<GreenNode> for GreenElement {
+impl From<Arc<GreenNode>> for GreenElement {
     #[inline]
-    fn from(node: GreenNode) -> GreenElement {
+    fn from(node: Arc<GreenNode>) -> GreenElement {
         NodeOrToken::Node(node)
     }
 }
 
-impl From<GreenToken> for GreenElement {
+impl From<Arc<GreenToken>> for GreenElement {
     #[inline]
-    fn from(token: GreenToken) -> GreenElement {
+    fn from(token: Arc<GreenToken>) -> GreenElement {
         NodeOrToken::Token(token)
     }
 }
@@ -26,6 +28,7 @@ impl GreenElement {
             NodeOrToken::Token(it) => it.kind(),
         }
     }
+
     /// Returns length of the text covered by this element.
     #[inline]
     pub fn text_len(&self) -> TextUnit {

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -2,39 +2,152 @@ use std::sync::Arc;
 
 use super::*;
 use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
+use std::{fmt, hash, mem, ptr};
 
-pub type GreenElement = NodeOrToken<Arc<GreenNode>, Arc<GreenToken>>;
+/// An owned element in a green tree.
+///
+// FIXME: add some green tree docs here
+pub struct GreenElement {
+    /// This ptr is either `ArcGreenNode` or `Arc<GreenToken> | 1`.
+    /// The low bit is available for a tag because
+    /// these pointers are `usize`-aligned.
+    raw: ptr::NonNull<()>,
+}
 
-impl From<Arc<GreenNode>> for GreenElement {
-    #[inline]
-    fn from(node: Arc<GreenNode>) -> GreenElement {
-        NodeOrToken::Node(node)
+unsafe impl Send for GreenElement {}
+unsafe impl Sync for GreenElement {}
+
+impl Drop for GreenElement {
+    fn drop(&mut self) {
+        unsafe {
+            if self.is_node() {
+                drop(ArcGreenNode::from_raw(self.raw.cast()))
+            } else {
+                let ptr = (self.raw.as_ptr() as usize & !1) as *const GreenToken;
+                drop(Arc::from_raw(ptr))
+            }
+        }
+    }
+}
+
+impl fmt::Debug for GreenElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match_element! { self => {
+            el => el.fmt(f),
+        }}
+    }
+}
+
+impl Clone for GreenElement {
+    fn clone(&self) -> GreenElement {
+        match_element! { self => {
+            el => el.to_owned().into(),
+        }}
+    }
+}
+
+impl Eq for GreenElement {}
+impl PartialEq for GreenElement {
+    fn eq(&self, other: &Self) -> bool {
+        if self.is_node() {
+            self.as_node() == other.as_node()
+        } else {
+            self.as_token() == other.as_token()
+        }
+    }
+}
+
+impl hash::Hash for GreenElement {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        match_element! { self => {
+            el => el.hash(state),
+        }}
     }
 }
 
 impl From<Arc<GreenToken>> for GreenElement {
     #[inline]
     fn from(token: Arc<GreenToken>) -> GreenElement {
-        NodeOrToken::Token(token)
+        let ptr = (Arc::into_raw(token) as usize | 1) as *mut ();
+        unsafe { GreenElement { raw: ptr::NonNull::new_unchecked(ptr) } }
+    }
+}
+
+impl From<GreenToken> for GreenElement {
+    fn from(token: GreenToken) -> GreenElement {
+        Arc::new(token).into()
+    }
+}
+
+impl From<ArcGreenNode> for GreenElement {
+    fn from(node: ArcGreenNode) -> GreenElement {
+        GreenElement { raw: ArcGreenNode::into_raw(node).cast() }
     }
 }
 
 impl GreenElement {
+    #[inline]
+    pub fn is_node(&self) -> bool {
+        self.raw.as_ptr() as usize & 1 == 0
+    }
+
+    #[inline]
+    pub fn is_token(&self) -> bool {
+        self.raw.as_ptr() as usize & 1 != 0
+    }
+
+    #[inline]
+    pub fn as_node(&self) -> Option<&GreenNode> {
+        if self.is_node() {
+            let ptr = self.raw.cast::<GreenNode>().as_ptr();
+            Some(unsafe { &*ptr })
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn unwrap_node(self) -> ArcGreenNode {
+        if self.is_node() {
+            let ptr = self.raw.cast::<GreenNode>();
+            mem::forget(self);
+            unsafe { ArcGreenNode::from_raw(ptr) }
+        } else {
+            panic!("called `unwrap_node` on a token")
+        }
+    }
+
+    #[inline]
+    pub fn as_token(&self) -> Option<&GreenToken> {
+        if self.is_token() {
+            let ptr = ((self.raw.as_ptr() as usize) & !1) as *const GreenToken;
+            unsafe { Some(&*ptr) }
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_enum(&self) -> NodeOrToken<&GreenNode, &GreenToken> {
+        match_element! { self => {
+            Node(node) => NodeOrToken::Node(node),
+            Token(token) => NodeOrToken::Token(token),
+        }}
+    }
+
     /// Returns kind of this element.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        match self {
-            NodeOrToken::Node(it) => it.kind(),
-            NodeOrToken::Token(it) => it.kind(),
-        }
+        match_element! { self => {
+            el => el.kind(),
+        }}
     }
 
     /// Returns length of the text covered by this element.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        match self {
-            NodeOrToken::Node(it) => it.text_len(),
-            NodeOrToken::Token(it) => it.text_len(),
-        }
+        match_element! { self => {
+            el => el.text_len(),
+        }}
     }
 }

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,0 +1,37 @@
+use super::*;
+use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
+
+pub type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+
+impl From<GreenNode> for GreenElement {
+    #[inline]
+    fn from(node: GreenNode) -> GreenElement {
+        NodeOrToken::Node(node)
+    }
+}
+
+impl From<GreenToken> for GreenElement {
+    #[inline]
+    fn from(token: GreenToken) -> GreenElement {
+        NodeOrToken::Token(token)
+    }
+}
+
+impl GreenElement {
+    /// Returns kind of this element.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        match self {
+            NodeOrToken::Node(it) => it.kind(),
+            NodeOrToken::Token(it) => it.kind(),
+        }
+    }
+    /// Returns length of the text covered by this element.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        match self {
+            NodeOrToken::Node(it) => it.text_len(),
+            NodeOrToken::Token(it) => it.text_len(),
+        }
+    }
+}

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -3,9 +3,5 @@ mod token;
 mod element;
 mod builder;
 
-pub use self::{
-    builder::*,
-    element::GreenElement,
-    node::{ArcGreenNode, GreenNode},
-    token::GreenToken,
-};
+pub use self::{builder::*, element::GreenElement, node::GreenNode, token::GreenToken};
+pub(crate) use node::ArcGreenNode;

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -3,4 +3,9 @@ mod token;
 mod element;
 mod builder;
 
-pub use self::{builder::*, element::GreenElement, node::GreenNode, token::GreenToken};
+pub use self::{
+    builder::*,
+    element::GreenElement,
+    node::{ArcGreenNode, GreenNode},
+    token::GreenToken,
+};

--- a/src/green/mod.rs
+++ b/src/green/mod.rs
@@ -1,0 +1,6 @@
+mod node;
+mod token;
+mod element;
+mod builder;
+
+pub use self::{builder::*, element::GreenElement, node::GreenNode, token::GreenToken};

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,37 +1,29 @@
 use std::{
-    alloc::{alloc, dealloc, handle_alloc_error, Layout},
-    borrow::Borrow,
-    convert::TryInto,
-    fmt, hash, isize,
-    mem::{self, ManuallyDrop},
-    ops::Deref,
-    ptr, slice,
-    sync::atomic::{self, AtomicU64, AtomicUsize, Ordering},
+    borrow::Borrow, fmt, hash, mem, ops::Deref, ptr, slice, sync::atomic::AtomicU64, sync::Arc,
 };
+use thin_dst::{ThinArc, ThinData};
 
 use super::*;
 use crate::{cursor::SyntaxKind, TextUnit};
+use std::hash::Hash;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-struct GreenNodeHead {
+pub(super) struct GreenNodeHead {
     kind: SyntaxKind,
     text_len: TextUnit,
-    child_len: u16,
 }
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
-#[repr(C)]
+#[repr(transparent)]
 pub struct GreenNode {
-    head: GreenNodeHead,
-    strong: AtomicUsize,
-    children: [GreenElement],
+    data: ThinData<GreenNodeHead, GreenElement>,
 }
 
 impl fmt::Debug for GreenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("GreenNode")
-            .field("head", &self.head)
+            .field("head", &self.data.head)
             .field("children", &self.children())
             .finish()
     }
@@ -40,187 +32,20 @@ impl fmt::Debug for GreenNode {
 impl Eq for GreenNode {}
 impl PartialEq for GreenNode {
     fn eq(&self, other: &GreenNode) -> bool {
-        self.head == other.head && self.children().eq(other.children())
+        self.data.head == other.data.head && self.children().eq(other.children())
     }
 }
 
 impl hash::Hash for GreenNode {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        self.head.hash(state);
+        self.data.head.hash(state);
         self.children().iter().for_each(|it| it.hash(state));
     }
 }
 
-#[test]
-fn node_layout() {
-    let node = unsafe { GreenNode::dummy() };
-    assert_eq!(GreenNode::align(), mem::align_of_val(node));
-    assert_eq!(GreenNode::size_for(0), mem::size_of_val(node));
-    assert_eq!(GreenNode::layout_for(0), Layout::for_value(node));
-    // FUTURE(ptr_offset_from: #41079): use `ptr::offset_from`
-    assert_eq!(
-        GreenNode::offset_of_strong(),
-        &node.strong as *const _ as *const () as isize - node as *const _ as *const () as isize
-    );
-    assert_eq!(
-        GreenNode::offset_of_head(),
-        &node.head as *const _ as *const () as isize - node as *const _ as *const () as isize
-    );
-    assert_eq!(
-        GreenNode::offset_of_children(),
-        &node.children as *const _ as *const () as isize - node as *const _ as *const () as isize
-    );
-}
-
-pub struct ArcGreenNode {
-    raw: ptr::NonNull<()>,
-}
-
-unsafe impl Send for ArcGreenNode {}
-unsafe impl Sync for ArcGreenNode {}
-
-impl Drop for ArcGreenNode {
-    // <https://github.com/rust-lang/rust/blob/2477e24/src/liballoc/sync.rs#L1195>
-    #[inline]
-    fn drop(&mut self) {
-        unsafe {
-            let mut raw = self.raw();
-            let raw = raw.as_mut();
-
-            // Because `fetch_sub` is already atomic, we do not need to synchronize
-            // with other threads unless we are going to delete the object.
-            if raw.strong.fetch_sub(1, Ordering::Release) != 1 {
-                return;
-            }
-
-            // This fence is needed to prevent reordering of use of the data and
-            // deletion of the data.  Because it is marked `Release`, the decreasing
-            // of the reference count synchronizes with this `Acquire` fence. This
-            // means that use of the data happens before decreasing the reference
-            // count, which happens before this fence, which happens before the
-            // deletion of the data.
-            //
-            // As explained in the [Boost documentation][1],
-            //
-            // > It is important to enforce any possible access to the object in one
-            // > thread (through an existing reference) to *happen before* deleting
-            // > the object in a different thread. This is achieved by a "release"
-            // > operation after dropping a reference (any access to the object
-            // > through this reference must obviously happened before), and an
-            // > "acquire" operation before deleting the object.
-            //
-            // In particular, while the contents of an Arc are usually immutable, it's
-            // possible to have interior writes to something like a Mutex<T>. Since a
-            // Mutex is not acquired when it is deleted, we can't rely on its
-            // synchronization logic to make writes in thread A visible to a destructor
-            // running in thread B.
-            //
-            // Also note that the Acquire fence here could probably be replaced with an
-            // Acquire load, which could improve performance in highly-contended
-            // situations. See [2].
-            //
-            // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
-            // [2]: (https://github.com/rust-lang/rust/pull/41714)
-            atomic::fence(Ordering::Acquire);
-
-            // Non-inlined part of `drop`.
-            unsafe fn drop_slow(raw: ptr::NonNull<GreenNode>) {
-                let child_count = raw.as_ref().head.child_len as usize;
-                ptr::drop_in_place(raw.as_ptr());
-                atomic::fence(Ordering::Acquire);
-                dealloc(raw.as_ptr().cast(), GreenNode::layout_for(child_count))
-            }
-
-            drop_slow(self.raw())
-            // NB: as this is a copy of the stdlib code, we are also subject to rust-lang/rust#55005
-        }
-    }
-}
-
-impl fmt::Debug for ArcGreenNode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        (**self).fmt(f)
-    }
-}
-
-impl Eq for ArcGreenNode {}
-impl PartialEq for ArcGreenNode {
-    fn eq(&self, other: &Self) -> bool {
-        **self == **other
-    }
-}
-
-impl hash::Hash for ArcGreenNode {
-    fn hash<H: hash::Hasher>(&self, state: &mut H) {
-        (**self).hash(state)
-    }
-}
-
-impl GreenNode {
-    #[inline]
-    fn alloc(kind: SyntaxKind, text_len: TextUnit, children: Vec<GreenElement>) -> ArcGreenNode {
-        let child_len: u16 = children.len().try_into().expect("node children array too big");
-        let strong = AtomicUsize::new(1);
-        let head = GreenNodeHead { kind, text_len, child_len };
-        let layout = GreenNode::layout_for(child_len as usize);
-
-        unsafe {
-            let ptr = ptr::NonNull::new(alloc(layout))
-                .unwrap_or_else(|| handle_alloc_error(layout))
-                .as_ptr();
-
-            ptr::write(ptr.offset(GreenNode::offset_of_head()).cast(), head);
-            ptr::write(ptr.offset(GreenNode::offset_of_strong()).cast(), strong);
-
-            let fam = ptr.offset(GreenNode::offset_of_children()).cast::<GreenElement>();
-            let children_ptr = children.as_ptr();
-            // Move children elements over in one go.
-            ptr::copy_nonoverlapping(children_ptr, fam, child_len as usize);
-            // Drop the source Vec without the elements we've just moved.
-            drop(mem::transmute::<Vec<GreenElement>, Vec<ManuallyDrop<GreenElement>>>(children));
-
-            ArcGreenNode::from_erased(ptr::NonNull::new_unchecked(ptr.cast()))
-        }
-    }
-
-    const fn align() -> usize {
-        let head_align = mem::align_of::<GreenNodeHead>();
-        let strong_align = mem::align_of::<AtomicUsize>();
-        let tail_align = mem::align_of::<GreenElement>();
-        // Get the max of [head_align, strong_align, tail_align] in a const-compatible way.
-        [
-            [head_align, strong_align][(head_align < strong_align) as usize], // true == 1usize
-            [tail_align, strong_align][(tail_align < strong_align) as usize], // true == 1usize
-        ][(head_align < tail_align) as usize] // true == 1usize
-    }
-
-    const fn size_for(child_count: usize) -> usize {
-        let tail_offset = GreenNode::offset_of_children() as usize;
-        let tail_size = mem::size_of::<GreenElement>() * child_count;
-        tail_offset + tail_size + tail_size % GreenNode::align()
-    }
-
-    const fn layout_for(child_count: usize) -> Layout {
-        unsafe {
-            Layout::from_size_align_unchecked(GreenNode::size_for(child_count), GreenNode::align())
-        }
-    }
-
-    const fn offset_of_head() -> isize {
-        0
-    }
-
-    const fn offset_of_strong() -> isize {
-        let head_size = mem::size_of::<GreenNodeHead>() as isize;
-        let strong_align = mem::align_of::<AtomicUsize>() as isize;
-        GreenNode::offset_of_head() + head_size + head_size % strong_align
-    }
-
-    const fn offset_of_children() -> isize {
-        let strong_size = mem::size_of::<AtomicUsize>() as isize;
-        let tail_align = mem::align_of::<GreenElement>() as isize;
-        GreenNode::offset_of_strong() + strong_size + strong_size % tail_align
-    }
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+pub(crate) struct ArcGreenNode {
+    pub(super) raw: ThinArc<GreenNodeHead, GreenElement>,
 }
 
 impl GreenNode {
@@ -231,9 +56,16 @@ impl GreenNode {
     /// You _can not_ upgrade this reference to `ArcGreenNode`.
     /// It is a fully valid `GreenNode` otherwise.
     pub(crate) unsafe fn dummy() -> &'static GreenNode {
-        static HEAD: [AtomicU64; 2] = [AtomicU64::new(0), AtomicU64::new(0)];
+        #[rustfmt::skip]
+        static HEAD: [AtomicU64; 8] = [ // 64 bytes should be enough
+            AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
+            AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0), AtomicU64::new(0),
+        ];
         // produce a zeroed GreenNodeHead with no children
-        &*(slice::from_raw_parts(HEAD.as_ptr(), 0) as *const [AtomicU64] as *const GreenNode)
+        let this =
+            &*(slice::from_raw_parts(HEAD.as_ptr(), 0) as *const [AtomicU64] as *const GreenNode);
+        debug_assert!(mem::size_of_val(this) <= mem::size_of_val(&HEAD));
+        this
     }
 
     pub(crate) fn dangling() -> ptr::NonNull<GreenNode> {
@@ -242,65 +74,44 @@ impl GreenNode {
 
     /// Creates new Node.
     #[inline]
-    #[allow(clippy::new_ret_no_self)]
-    pub fn new(kind: SyntaxKind, children: Vec<GreenElement>) -> ArcGreenNode {
-        let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        GreenNode::alloc(kind, text_len, children)
+    pub fn new<I>(kind: SyntaxKind, children: I) -> Arc<GreenNode>
+    where
+        I: IntoIterator<Item = GreenElement>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let mut text_len: TextUnit = 0.into();
+        let children = children.into_iter().inspect(|it| text_len += it.text_len());
+        let res = ThinArc::new(GreenNodeHead { kind, text_len: 0.into() }, children);
+        let mut res: Arc<ThinData<GreenNodeHead, GreenElement>> = res.into();
+        Arc::get_mut(&mut res).unwrap().head.text_len = text_len;
+        unsafe { mem::transmute(res) }
     }
 
     /// Kind of this node.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.head.kind
+        self.data.head.kind
     }
 
     /// Length of the text, covered by this node.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        self.head.text_len
+        self.data.head.text_len
     }
 
     /// Children of this node.
     #[inline]
     pub fn children(&self) -> &[GreenElement] {
-        unsafe { slice::from_raw_parts(self.children.as_ptr(), self.head.child_len as usize) }
-    }
-}
-
-impl ArcGreenNode {
-    pub(super) fn raw(&self) -> ptr::NonNull<GreenNode> {
-        unsafe { ArcGreenNode::unerase(self.raw) }
-    }
-
-    pub(super) fn into_raw(self) -> ptr::NonNull<GreenNode> {
-        let raw = self.raw();
-        mem::forget(self);
-        raw
-    }
-
-    pub(super) unsafe fn from_raw(raw: ptr::NonNull<GreenNode>) -> ArcGreenNode {
-        ArcGreenNode { raw: raw.cast() }
-    }
-
-    pub(super) unsafe fn from_erased(raw: ptr::NonNull<()>) -> ArcGreenNode {
-        ArcGreenNode::from_raw(ArcGreenNode::unerase(raw))
-    }
-
-    pub(super) unsafe fn unerase(raw: ptr::NonNull<()>) -> ptr::NonNull<GreenNode> {
-        assert_eq!(GreenNode::offset_of_head(), 0); // optimized out safety note
-        let head = raw.cast::<GreenNodeHead>();
-        let head = head.as_ref();
-        // FUTURE(slice_from_raw_parts: #36925): use ptr::slice_from_raw_parts
-        let slice: *const [()] = slice::from_raw_parts(raw.as_ptr(), head.child_len as usize);
-        #[allow(clippy::cast_ptr_alignment)]
-        ptr::NonNull::new_unchecked(slice as *const GreenNode as *mut GreenNode)
+        &self.data.slice
     }
 }
 
 impl Deref for ArcGreenNode {
     type Target = GreenNode;
     fn deref(&self) -> &GreenNode {
-        unsafe { &*self.raw().as_ptr() }
+        unsafe {
+            &*((&*self.raw) as *const ThinData<GreenNodeHead, GreenElement> as *const GreenNode)
+        }
     }
 }
 
@@ -316,49 +127,14 @@ impl AsRef<GreenNode> for ArcGreenNode {
     }
 }
 
-impl Clone for ArcGreenNode {
-    // <https://github.com/rust-lang/rust/blob/2477e24/src/liballoc/sync.rs#L924>
-    fn clone(&self) -> ArcGreenNode {
-        let node = &**self;
-
-        // Using a relaxed ordering is alright here, as knowledge of the
-        // original reference prevents other threads from erroneously deleting
-        // the object.
-        //
-        // As explained in the [Boost documentation][1], Increasing the
-        // reference counter can always be done with memory_order_relaxed: New
-        // references to an object can only be formed from an existing
-        // reference, and passing an existing reference from one thread to
-        // another must already provide any required synchronization.
-        //
-        // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
-        let old_size = node.strong.fetch_add(1, Ordering::Relaxed);
-
-        // However we need to guard against massive refcounts in case someone
-        // is `mem::forget`ing Arcs. If we don't do this the count can overflow
-        // and users will use-after free. We racily saturate to `isize::MAX` on
-        // the assumption that there aren't ~2 billion threads incrementing
-        // the reference count at once. This branch will never be taken in
-        // any realistic program.
-        //
-        // We abort because such a program is incredibly degenerate, and we
-        // don't care to support it.
-        if old_size > isize::MAX as usize {
-            std::process::abort();
-        }
-
-        unsafe { Self::from_raw(node.into()) }
-    }
-}
-
 impl ToOwned for GreenNode {
-    type Owned = ArcGreenNode;
+    type Owned = Arc<GreenNode>;
 
-    fn to_owned(&self) -> ArcGreenNode {
+    fn to_owned(&self) -> Arc<GreenNode> {
         unsafe {
-            // This is safe because all `GreenNode`s live behind an `ArcGreenNode`.
-            let arc = ArcGreenNode::from_raw(self.into());
-            // NB: The real owning `ArcGreenNode` cannot be dropped here because it is borrowed.
+            // This is safe because all `GreenNode`s live behind an `Arc`.
+            let arc = Arc::from_raw(self as *const GreenNode);
+            // NB: The real owning `Arc` cannot be dropped here because it is borrowed.
             // Don't forget to increase the reference count!
             mem::forget(arc.clone());
             arc

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,37 +1,143 @@
-use std::sync::Arc;
+use static_assertions::*;
+use std::{
+    alloc::{alloc, dealloc, Layout},
+    mem, ptr, slice,
+    sync::Arc,
+};
 
 use super::*;
 use crate::{cursor::SyntaxKind, TextUnit};
+use std::alloc::handle_alloc_error;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+struct GreenNodeHead {
+    kind: SyntaxKind,
+    text_len: TextUnit,
+}
+
+assert_eq_size!(GreenNodeHead, u64);
+assert_eq_align!(GreenNodeHead, u32);
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(C)]
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct GreenNode {
-    kind: SyntaxKind,
-    text_len: TextUnit,
-    //TODO: implement llvm::trailing_objects trick
-    children: Arc<[GreenElement]>,
+    head: GreenNodeHead,
+    children: [GreenElement],
+}
+
+#[test]
+fn node_layout() {
+    let node = unsafe { GreenNode::dummy() };
+    assert_eq!(GreenNode::align(), mem::align_of_val(node));
+    assert_eq!(GreenNode::size_for(0), mem::size_of_val(node));
+    assert_eq!(GreenNode::layout_for(0), Layout::for_value(node));
+    assert_eq!(
+        GreenNode::offset_of_head(),
+        &node.head as *const _ as *const () as isize - node as *const _ as *const () as isize
+    );
+    assert_eq!(
+        GreenNode::offset_of_children(),
+        &node.children as *const _ as *const () as isize - node as *const _ as *const () as isize
+    );
 }
 
 impl GreenNode {
+    #[inline]
+    fn alloc<I>(kind: SyntaxKind, text_len: TextUnit, children: I) -> Arc<GreenNode>
+    where
+        I: Iterator<Item = GreenElement> + ExactSizeIterator,
+    {
+        let len = children.len();
+        let head = GreenNodeHead { kind, text_len };
+        let layout = GreenNode::layout_for(len);
+
+        let boxed = unsafe {
+            let ptr = ptr::NonNull::new(alloc(layout))
+                .unwrap_or_else(|| handle_alloc_error(layout))
+                .as_ptr();
+
+            ptr::write(ptr.offset(GreenNode::offset_of_head()).cast(), head);
+
+            let mut fam = ptr.offset(GreenNode::offset_of_children()).cast::<GreenElement>();
+            for child in children {
+                ptr::write(fam, child);
+                fam = fam.offset(1);
+            }
+
+            let ptr: *mut [u8] = slice::from_raw_parts_mut(ptr, len);
+            Box::from_raw(ptr as *mut GreenNode)
+        };
+
+        // NB: this creates a new allocation for the Arc, moves into it, and drops the Box.
+        // We cannot allocate an Arc directly, so it's this or implementing a custom Arc.
+        boxed.into()
+    }
+
+    const fn align() -> usize {
+        let head_align = mem::align_of::<GreenNodeHead>();
+        let tail_align = mem::align_of::<GreenElement>();
+        [head_align, tail_align][(head_align < tail_align) as usize] // true == 1usize
+    }
+
+    const fn size_for(child_count: usize) -> usize {
+        let head_size = mem::size_of::<GreenNodeHead>();
+        let tail_align = mem::align_of::<GreenElement>();
+        let tail_size = mem::size_of::<GreenElement>() * child_count;
+        head_size + head_size % tail_align + tail_size + tail_size % GreenNode::align()
+        // head ^   ^^^^^^^ padding ^^^^^^   ^^ tail ^   ^^^^^^^^^^^ padding ^^^^^^^^^^
+    }
+
+    const fn layout_for(child_count: usize) -> Layout {
+        unsafe {
+            Layout::from_size_align_unchecked(GreenNode::size_for(child_count), GreenNode::align())
+        }
+    }
+
+    const fn offset_of_head() -> isize {
+        0
+    }
+
+    const fn offset_of_children() -> isize {
+        let head_size = mem::size_of::<GreenNodeHead>() as isize;
+        let tail_align = mem::align_of::<GreenElement>() as isize;
+        GreenNode::offset_of_head() + head_size + head_size % tail_align
+    }
+}
+
+impl GreenNode {
+    /// A dummy `GreenNode` for use as a placeholder.
+    ///
+    /// # Safety
+    ///
+    /// You _can not_ upgrade this reference to `Arc`.
+    /// It is a fully valid `GreenNode` otherwise.
+    pub(crate) unsafe fn dummy() -> &'static GreenNode {
+        static HEAD: u64 = 0;
+        // produce a `mem::zeroed` GreenNodeHead with no children
+        &*(slice::from_raw_parts(&HEAD, 0) as *const [u64] as *const GreenNode)
+    }
+
     /// Creates new Node.
     #[inline]
-    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> Arc<GreenNode> {
+    pub fn new(kind: SyntaxKind, children: Vec<GreenElement>) -> Arc<GreenNode> {
         let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        Arc::new(GreenNode { kind, text_len, children: children.into() })
+        GreenNode::alloc(kind, text_len, children.into_iter())
     }
 
     /// Kind of this node.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.kind
+        self.head.kind
     }
 
     /// Length of the text, covered by this node.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        self.text_len
+        self.head.text_len
     }
+
     /// Children of this node.
     #[inline]
     pub fn children(&self) -> &[GreenElement] {

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -16,9 +16,9 @@ pub struct GreenNode {
 impl GreenNode {
     /// Creates new Node.
     #[inline]
-    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> Arc<GreenNode> {
         let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
-        GreenNode { kind, text_len, children: children.into() }
+        Arc::new(GreenNode { kind, text_len, children: children.into() })
     }
 
     /// Kind of this node.

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -144,3 +144,18 @@ impl GreenNode {
         &self.children
     }
 }
+
+impl ToOwned for GreenNode {
+    type Owned = Arc<GreenNode>;
+
+    fn to_owned(&self) -> Self::Owned {
+        unsafe {
+            // This is safe because all `GreenNode`s live behind an `Arc`.
+            let arc = Arc::from_raw(self);
+            // NB: The real owning `Arc` cannot be dropped here because it is borrowed.
+            // Don't forget to increase the reference count!
+            mem::forget(arc.clone());
+            arc
+        }
+    }
+}

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,18 +1,22 @@
 use static_assertions::*;
 use std::{
-    alloc::{alloc, dealloc, Layout},
-    mem, ptr, slice,
-    sync::Arc,
+    alloc::{alloc, dealloc, handle_alloc_error, Layout},
+    borrow::Borrow,
+    convert::TryInto,
+    fmt, hash, isize, mem,
+    ops::Deref,
+    ptr, slice,
+    sync::atomic::{self, AtomicUsize, Ordering},
 };
 
 use super::*;
 use crate::{cursor::SyntaxKind, TextUnit};
-use std::alloc::handle_alloc_error;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 struct GreenNodeHead {
     kind: SyntaxKind,
     text_len: TextUnit,
+    child_len: u16,
 }
 
 assert_eq_size!(GreenNodeHead, u64);
@@ -20,19 +24,65 @@ assert_eq_align!(GreenNodeHead, u32);
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
+///
+/// # Safety
+///
+/// This struct is _not actually `Sized`_!
+/// It is only safe as `&GreenNode`, `GreenElement`, or `ArcGreenNode`.
 #[repr(C)]
-#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct GreenNode {
     head: GreenNodeHead,
-    children: [GreenElement],
+    strong: AtomicUsize,
+    children: [GreenElement; 0],
+}
+
+assert_eq_align!(GreenNode, usize);
+assert_eq_size!(GreenNode, [u64; 2]);
+
+impl Drop for GreenNode {
+    fn drop(&mut self) {
+        for child in self.children_mut() {
+            unsafe { ptr::drop_in_place(child) }
+        }
+    }
+}
+
+impl fmt::Debug for GreenNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GreenNode")
+            .field("head", &self.head)
+            .field("strong", &self.strong)
+            .field("children", &self.children())
+            .finish()
+    }
+}
+
+impl Eq for GreenNode {}
+impl PartialEq for GreenNode {
+    fn eq(&self, other: &GreenNode) -> bool {
+        self.head == other.head && self.children().eq(other.children())
+    }
+}
+
+impl hash::Hash for GreenNode {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.head.hash(state);
+        self.children().iter().for_each(|it| it.hash(state));
+    }
 }
 
 #[test]
+#[cfg(not(miri))]
 fn node_layout() {
     let node = unsafe { GreenNode::dummy() };
     assert_eq!(GreenNode::align(), mem::align_of_val(node));
     assert_eq!(GreenNode::size_for(0), mem::size_of_val(node));
     assert_eq!(GreenNode::layout_for(0), Layout::for_value(node));
+    // FUTURE(ptr_offset_from: #41079): use `ptr::offset_from`
+    assert_eq!(
+        GreenNode::offset_of_strong(),
+        &node.strong as *const _ as *const () as isize - node as *const _ as *const () as isize
+    );
     assert_eq!(
         GreenNode::offset_of_head(),
         &node.head as *const _ as *const () as isize - node as *const _ as *const () as isize
@@ -43,22 +93,107 @@ fn node_layout() {
     );
 }
 
+pub struct ArcGreenNode {
+    raw: ptr::NonNull<GreenNode>,
+}
+
+unsafe impl Send for ArcGreenNode {}
+unsafe impl Sync for ArcGreenNode {}
+
+impl Drop for ArcGreenNode {
+    // <https://github.com/rust-lang/rust/blob/2477e24/src/liballoc/sync.rs#L1195>
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            let raw = self.raw.as_mut();
+
+            // Because `fetch_sub` is already atomic, we do not need to synchronize
+            // with other threads unless we are going to delete the object.
+            if raw.strong.fetch_sub(1, Ordering::Release) != 1 {
+                return;
+            }
+
+            // This fence is needed to prevent reordering of use of the data and
+            // deletion of the data.  Because it is marked `Release`, the decreasing
+            // of the reference count synchronizes with this `Acquire` fence. This
+            // means that use of the data happens before decreasing the reference
+            // count, which happens before this fence, which happens before the
+            // deletion of the data.
+            //
+            // As explained in the [Boost documentation][1],
+            //
+            // > It is important to enforce any possible access to the object in one
+            // > thread (through an existing reference) to *happen before* deleting
+            // > the object in a different thread. This is achieved by a "release"
+            // > operation after dropping a reference (any access to the object
+            // > through this reference must obviously happened before), and an
+            // > "acquire" operation before deleting the object.
+            //
+            // In particular, while the contents of an Arc are usually immutable, it's
+            // possible to have interior writes to something like a Mutex<T>. Since a
+            // Mutex is not acquired when it is deleted, we can't rely on its
+            // synchronization logic to make writes in thread A visible to a destructor
+            // running in thread B.
+            //
+            // Also note that the Acquire fence here could probably be replaced with an
+            // Acquire load, which could improve performance in highly-contended
+            // situations. See [2].
+            //
+            // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
+            // [2]: (https://github.com/rust-lang/rust/pull/41714)
+            atomic::fence(Ordering::Acquire);
+
+            // Non-inlined part of `drop`.
+            unsafe fn drop_slow(raw: ptr::NonNull<GreenNode>) {
+                let child_count = raw.as_ref().head.child_len as usize;
+                ptr::drop_in_place(raw.as_ptr());
+                atomic::fence(Ordering::Acquire);
+                dealloc(raw.as_ptr().cast(), GreenNode::layout_for(child_count))
+            }
+
+            drop_slow(self.raw)
+            // NB: as this is a copy of the stdlib code, we are also subject to rust-lang/rust#55005
+        }
+    }
+}
+
+impl fmt::Debug for ArcGreenNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        (**self).fmt(f)
+    }
+}
+
+impl Eq for ArcGreenNode {}
+impl PartialEq for ArcGreenNode {
+    fn eq(&self, other: &Self) -> bool {
+        **self == **other
+    }
+}
+
+impl hash::Hash for ArcGreenNode {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        (**self).hash(state)
+    }
+}
+
 impl GreenNode {
     #[inline]
-    fn alloc<I>(kind: SyntaxKind, text_len: TextUnit, children: I) -> Arc<GreenNode>
+    fn alloc<I>(kind: SyntaxKind, text_len: TextUnit, children: I) -> ArcGreenNode
     where
         I: Iterator<Item = GreenElement> + ExactSizeIterator,
     {
-        let len = children.len();
-        let head = GreenNodeHead { kind, text_len };
-        let layout = GreenNode::layout_for(len);
+        let child_len: u16 = children.len().try_into().expect("node children array too big");
+        let strong = AtomicUsize::new(1);
+        let head = GreenNodeHead { kind, text_len, child_len };
+        let layout = GreenNode::layout_for(child_len as usize);
 
-        let boxed = unsafe {
+        unsafe {
             let ptr = ptr::NonNull::new(alloc(layout))
                 .unwrap_or_else(|| handle_alloc_error(layout))
                 .as_ptr();
 
             ptr::write(ptr.offset(GreenNode::offset_of_head()).cast(), head);
+            ptr::write(ptr.offset(GreenNode::offset_of_strong()).cast(), strong);
 
             let mut fam = ptr.offset(GreenNode::offset_of_children()).cast::<GreenElement>();
             for child in children {
@@ -66,27 +201,26 @@ impl GreenNode {
                 fam = fam.offset(1);
             }
 
-            let ptr: *mut [u8] = slice::from_raw_parts_mut(ptr, len);
-            Box::from_raw(ptr as *mut GreenNode)
-        };
-
-        // NB: this creates a new allocation for the Arc, moves into it, and drops the Box.
-        // We cannot allocate an Arc directly, so it's this or implementing a custom Arc.
-        boxed.into()
+            #[allow(clippy::cast_ptr_alignment)]
+            ArcGreenNode::from_raw(ptr::NonNull::new_unchecked(ptr as *mut GreenNode))
+        }
     }
 
     const fn align() -> usize {
         let head_align = mem::align_of::<GreenNodeHead>();
+        let strong_align = mem::align_of::<AtomicUsize>();
         let tail_align = mem::align_of::<GreenElement>();
-        [head_align, tail_align][(head_align < tail_align) as usize] // true == 1usize
+        // Get the max of [head_align, strong_align, tail_align] in a const-compatible way.
+        [
+            [head_align, strong_align][(head_align < strong_align) as usize], // true == 1usize
+            [tail_align, strong_align][(tail_align < strong_align) as usize], // true == 1usize
+        ][(head_align < tail_align) as usize] // true == 1usize
     }
 
     const fn size_for(child_count: usize) -> usize {
-        let head_size = mem::size_of::<GreenNodeHead>();
-        let tail_align = mem::align_of::<GreenElement>();
+        let tail_offset = GreenNode::offset_of_children() as usize;
         let tail_size = mem::size_of::<GreenElement>() * child_count;
-        head_size + head_size % tail_align + tail_size + tail_size % GreenNode::align()
-        // head ^   ^^^^^^^ padding ^^^^^^   ^^ tail ^   ^^^^^^^^^^^ padding ^^^^^^^^^^
+        tail_offset + tail_size + tail_size % GreenNode::align()
     }
 
     const fn layout_for(child_count: usize) -> Layout {
@@ -99,10 +233,16 @@ impl GreenNode {
         0
     }
 
-    const fn offset_of_children() -> isize {
+    const fn offset_of_strong() -> isize {
         let head_size = mem::size_of::<GreenNodeHead>() as isize;
+        let strong_align = mem::align_of::<AtomicUsize>() as isize;
+        GreenNode::offset_of_head() + head_size + head_size % strong_align
+    }
+
+    const fn offset_of_children() -> isize {
+        let strong_size = mem::size_of::<AtomicUsize>() as isize;
         let tail_align = mem::align_of::<GreenElement>() as isize;
-        GreenNode::offset_of_head() + head_size + head_size % tail_align
+        GreenNode::offset_of_strong() + strong_size + strong_size % tail_align
     }
 }
 
@@ -111,17 +251,23 @@ impl GreenNode {
     ///
     /// # Safety
     ///
-    /// You _can not_ upgrade this reference to `Arc`.
+    /// You _can not_ upgrade this reference to `ArcGreenNode`.
     /// It is a fully valid `GreenNode` otherwise.
+    #[cfg(test)]
     pub(crate) unsafe fn dummy() -> &'static GreenNode {
-        static HEAD: u64 = 0;
-        // produce a `mem::zeroed` GreenNodeHead with no children
-        &*(slice::from_raw_parts(&HEAD, 0) as *const [u64] as *const GreenNode)
+        static HEAD: [u64; 8] = [0; 8];
+        // produce a zeroed GreenNodeHead with no children
+        &*(&HEAD as *const u64 as *const GreenNode)
+    }
+
+    pub(crate) const fn dangling() -> ptr::NonNull<GreenNode> {
+        unsafe { ptr::NonNull::new_unchecked(GreenNode::align() as *mut _) }
     }
 
     /// Creates new Node.
     #[inline]
-    pub fn new(kind: SyntaxKind, children: Vec<GreenElement>) -> Arc<GreenNode> {
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(kind: SyntaxKind, children: Vec<GreenElement>) -> ArcGreenNode {
         let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
         GreenNode::alloc(kind, text_len, children.into_iter())
     }
@@ -141,18 +287,90 @@ impl GreenNode {
     /// Children of this node.
     #[inline]
     pub fn children(&self) -> &[GreenElement] {
-        &self.children
+        unsafe { slice::from_raw_parts(self.children.as_ptr(), self.head.child_len as usize) }
+    }
+
+    fn children_mut(&mut self) -> &mut [GreenElement] {
+        unsafe {
+            slice::from_raw_parts_mut(self.children.as_mut_ptr(), self.head.child_len as usize)
+        }
+    }
+}
+
+impl ArcGreenNode {
+    pub(super) fn into_raw(self) -> ptr::NonNull<GreenNode> {
+        let raw = self.raw;
+        mem::forget(self);
+        raw
+    }
+
+    pub(super) unsafe fn from_raw(raw: ptr::NonNull<GreenNode>) -> ArcGreenNode {
+        ArcGreenNode { raw }
+    }
+}
+
+impl Deref for ArcGreenNode {
+    type Target = GreenNode;
+    fn deref(&self) -> &GreenNode {
+        unsafe { self.raw.as_ref() }
+    }
+}
+
+impl Borrow<GreenNode> for ArcGreenNode {
+    fn borrow(&self) -> &GreenNode {
+        &**self
+    }
+}
+
+impl AsRef<GreenNode> for ArcGreenNode {
+    fn as_ref(&self) -> &GreenNode {
+        &**self
+    }
+}
+
+impl Clone for ArcGreenNode {
+    // <https://github.com/rust-lang/rust/blob/2477e24/src/liballoc/sync.rs#L924>
+    fn clone(&self) -> ArcGreenNode {
+        let node = &**self;
+
+        // Using a relaxed ordering is alright here, as knowledge of the
+        // original reference prevents other threads from erroneously deleting
+        // the object.
+        //
+        // As explained in the [Boost documentation][1], Increasing the
+        // reference counter can always be done with memory_order_relaxed: New
+        // references to an object can only be formed from an existing
+        // reference, and passing an existing reference from one thread to
+        // another must already provide any required synchronization.
+        //
+        // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
+        let old_size = node.strong.fetch_add(1, Ordering::Relaxed);
+
+        // However we need to guard against massive refcounts in case someone
+        // is `mem::forget`ing Arcs. If we don't do this the count can overflow
+        // and users will use-after free. We racily saturate to `isize::MAX` on
+        // the assumption that there aren't ~2 billion threads incrementing
+        // the reference count at once. This branch will never be taken in
+        // any realistic program.
+        //
+        // We abort because such a program is incredibly degenerate, and we
+        // don't care to support it.
+        if old_size > isize::MAX as usize {
+            std::process::abort();
+        }
+
+        unsafe { Self::from_raw(node.into()) }
     }
 }
 
 impl ToOwned for GreenNode {
-    type Owned = Arc<GreenNode>;
+    type Owned = ArcGreenNode;
 
-    fn to_owned(&self) -> Self::Owned {
+    fn to_owned(&self) -> ArcGreenNode {
         unsafe {
-            // This is safe because all `GreenNode`s live behind an `Arc`.
-            let arc = Arc::from_raw(self);
-            // NB: The real owning `Arc` cannot be dropped here because it is borrowed.
+            // This is safe because all `GreenNode`s live behind an `ArcGreenNode`.
+            let arc = ArcGreenNode::from_raw(self.into());
+            // NB: The real owning `ArcGreenNode` cannot be dropped here because it is borrowed.
             // Don't forget to increase the reference count!
             mem::forget(arc.clone());
             arc

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use super::*;
+use crate::{cursor::SyntaxKind, TextUnit};
+
+/// Internal node in the immutable tree.
+/// It has other nodes and tokens as children.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GreenNode {
+    kind: SyntaxKind,
+    text_len: TextUnit,
+    //TODO: implement llvm::trailing_objects trick
+    children: Arc<[GreenElement]>,
+}
+
+impl GreenNode {
+    /// Creates new Node.
+    #[inline]
+    pub fn new(kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+        let text_len = children.iter().map(|x| x.text_len()).sum::<TextUnit>();
+        GreenNode { kind, text_len, children: children.into() }
+    }
+
+    /// Kind of this node.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
+    }
+
+    /// Length of the text, covered by this node.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        self.text_len
+    }
+    /// Children of this node.
+    #[inline]
+    pub fn children(&self) -> &[GreenElement] {
+        &self.children
+    }
+}

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,0 +1,31 @@
+use crate::{cursor::SyntaxKind, SmolStr, TextUnit};
+
+/// Leaf node in the immutable tree.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct GreenToken {
+    kind: SyntaxKind,
+    text: SmolStr,
+}
+
+impl GreenToken {
+    /// Creates new Token.
+    #[inline]
+    pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
+        GreenToken { kind, text }
+    }
+    /// Kind of this Token.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        self.kind
+    }
+    /// Text of this Token.
+    #[inline]
+    pub fn text(&self) -> &SmolStr {
+        &self.text
+    }
+    /// Text of this Token.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        TextUnit::from_usize(self.text.len())
+    }
+}

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -13,16 +13,19 @@ impl GreenToken {
     pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
         GreenToken { kind, text }
     }
+
     /// Kind of this Token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
         self.kind
     }
+
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &SmolStr {
         &self.text
     }
+
     /// Text of this Token.
     #[inline]
     pub fn text_len(&self) -> TextUnit {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,10 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
-#![allow(unused)]
+//#![allow(unused)]
+
+#[macro_use]
+mod utility_types;
 
 #[allow(unsafe_code)]
 mod green;
@@ -15,11 +18,8 @@ mod green;
 pub mod cursor;
 pub mod api;
 mod syntax_text;
-mod utility_types;
 #[cfg(feature = "serde1")]
 mod serde_impls;
-
-use green::GreenElement;
 
 // Reexport types for working with strings. We might be too opinionated about
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
@@ -29,7 +29,7 @@ pub use text_unit::{TextRange, TextUnit};
 
 pub use crate::{
     api::*,
-    green::{Checkpoint, GreenNode, GreenNodeBuilder, GreenToken},
+    green::{ArcGreenNode, Checkpoint, GreenNode, GreenNodeBuilder, GreenToken, GreenElement},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
-        f::<Arc<GreenNode>>();
+        f::<ArcGreenNode>();
     }
 
     #[test]
@@ -50,7 +50,7 @@ mod tests {
         use std::mem::size_of;
 
         eprintln!("GreenToken      {}", size_of::<GreenToken>());
-        eprintln!("Arc<GreenNode>  {}", size_of::<Arc<GreenNode>>());
+        eprintln!("ArcGreenNode    {}", size_of::<ArcGreenNode>());
         eprintln!("Arc<GreenToken> {}", size_of::<Arc<GreenToken>>());
         eprintln!("GreenElement    {}", size_of::<GreenElement>());
         eprintln!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,7 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
-#![allow(unused)]
 
-#[warn(unused)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 #![deny(unsafe_code)]
 #![allow(unused)]
 
+#[warn(unused)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use text_unit::{TextRange, TextUnit};
 
 pub use crate::{
     api::*,
-    green::{ArcGreenNode, Checkpoint, GreenNode, GreenNodeBuilder, GreenToken, GreenElement},
+    green::{Checkpoint, GreenElement, GreenNode, GreenNodeBuilder, GreenToken},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
@@ -42,7 +42,7 @@ mod tests {
     #[test]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
-        f::<ArcGreenNode>();
+        f::<Arc<GreenNode>>();
     }
 
     #[test]
@@ -50,7 +50,7 @@ mod tests {
         use std::mem::size_of;
 
         eprintln!("GreenToken      {}", size_of::<GreenToken>());
-        eprintln!("ArcGreenNode    {}", size_of::<ArcGreenNode>());
+        eprintln!("Arc<GreenNode>  {}", size_of::<Arc<GreenNode>>());
         eprintln!("Arc<GreenToken> {}", size_of::<Arc<GreenToken>>());
         eprintln!("GreenElement    {}", size_of::<GreenElement>());
         eprintln!();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,9 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
+#![allow(unused)]
 
+#[allow(unsafe_code)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;
@@ -35,20 +37,22 @@ pub use crate::{
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
 
     #[test]
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
-        f::<GreenNode>();
+        f::<Arc<GreenNode>>();
     }
 
     #[test]
     fn test_size_of() {
         use std::mem::size_of;
 
-        eprintln!("GreenNode    {}", size_of::<GreenNode>());
-        eprintln!("GreenToken   {}", size_of::<GreenToken>());
-        eprintln!("GreenElement {}", size_of::<GreenElement>());
+        eprintln!("GreenToken      {}", size_of::<GreenToken>());
+        eprintln!("Arc<GreenNode>  {}", size_of::<Arc<GreenNode>>());
+        eprintln!("Arc<GreenToken> {}", size_of::<Arc<GreenToken>>());
+        eprintln!("GreenElement    {}", size_of::<GreenElement>());
         eprintln!();
         eprintln!("SyntaxNode    {}", size_of::<cursor::SyntaxNode>());
         eprintln!("SyntaxToken   {}", size_of::<cursor::SyntaxToken>());

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -263,7 +263,7 @@ mod tests {
             builder.token(SyntaxKind(92), chunk.into())
         }
         builder.finish_node();
-        SyntaxNode::new_root(builder.finish())
+        SyntaxNode::new_root(builder.finish().unwrap_node())
     }
 
     #[test]

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -1,8 +1,8 @@
-use std::{fmt, ops};
+use std::fmt;
 
 use crate::{
-    cursor::{SyntaxElement, SyntaxNode, SyntaxToken},
-    NodeOrToken, SmolStr, TextRange, TextUnit,
+    cursor::{SyntaxNode, SyntaxToken},
+    TextRange, TextUnit,
 };
 
 #[derive(Clone)]
@@ -43,7 +43,6 @@ impl SyntaxText {
     }
 
     pub fn char_at(&self, offset: TextUnit) -> Option<char> {
-        let offset = offset.into();
         let mut start: TextUnit = 0.into();
         let res = self.try_for_each_chunk(|chunk| {
             let end = start + TextUnit::of_str(chunk);
@@ -59,7 +58,7 @@ impl SyntaxText {
 
     pub fn slice<R: private::SyntaxTextRange>(&self, range: R) -> SyntaxText {
         let start = range.start().unwrap_or_default();
-        let end = range.end().unwrap_or(self.len());
+        let end = range.end().unwrap_or_else(|| self.len());
         assert!(start <= end);
         let len = end - start;
         let start = self.range.start() + start;
@@ -97,6 +96,7 @@ impl SyntaxText {
 
     pub fn for_each_chunk<F: FnMut(&str)>(&self, mut f: F) {
         enum Void {}
+        #[allow(clippy::unit_arg)]
         match self.try_for_each_chunk(|chunk| Ok::<(), Void>(f(chunk))) {
             Ok(()) => (),
             Err(void) => match void {},
@@ -191,7 +191,6 @@ fn zip_texts<I: Iterator<Item = (SyntaxToken, TextRange)>>(xs: &mut I, ys: &mut 
         x.1 = TextRange::from_to(x.1.start(), x.1.len() - advance);
         y.1 = TextRange::from_to(y.1.start(), y.1.len() - advance);
     }
-    None
 }
 
 impl Eq for SyntaxText {}

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,3 +1,32 @@
+#[macro_export]
+macro_rules! match_element {
+    ($el:expr => {
+        Node($node:pat) => $if_node:expr,
+        Token($token:pat) => $if_token:expr,
+    }) => {{
+        match $el {
+            el => {
+                if let Some($node) = el.as_node() {
+                    $if_node
+                } else {
+                    // NB: the unwrap should optimize out
+                    let $token = el.as_token().unwrap();
+                    $if_token
+                }
+            }
+        }
+    }};
+
+    ($el:expr => {
+        $elem:pat => $if_elem:expr,
+    }) => {{
+        crate::match_element! { $el => {
+            Node($elem) => $if_elem,
+            Token($elem) => $if_elem,
+        }}
+    }};
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
     Node(N),

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,7 +1,3 @@
-use std::{iter, ops::Range};
-
-use crate::{TextRange, TextUnit};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
     Node(N),


### PR DESCRIPTION
Implements a thin-pointer version of `GreenNode` and uses that to implement a 1×`usize` `GreenElement`. We do not yet apply any manual niching to `SyntaxElement`, though it still could [be niched to 2×`usize`](https://github.com/rust-lang/rust/issues/66029) at zero performance cost.

We provide a `match_element!` macro that allows for (what looks like) pattern matching over `GreenElement` even though it is no longer an enum.

```
GreenToken      32
ArcGreenNode    8
Arc<GreenToken> 8
GreenElement    8

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```

This passes miri! 🎉 We should probably add miri to CI to make sure it stays that way.