### PR TITLE
Lint on unused

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1,10 +1,8 @@
 use std::{
-    cell::{Cell, RefCell},
+    cell::RefCell,
     fmt,
     hash::{Hash, Hasher},
-    iter,
-    marker::PhantomData,
-    mem, ptr,
+    iter, mem, ptr,
     rc::Rc,
     slice,
 };
@@ -594,7 +592,7 @@ impl SyntaxToken {
             .children_to(self.index as usize, self.text_range().start())
             .next()?;
 
-        Some(NodeOrToken::new(element, self.parent(), index as u32, offset))
+        Some(NodeOrToken::new(element, parent, index as u32, offset))
     }
 
     pub fn siblings_with_tokens(
@@ -733,7 +731,7 @@ impl Iter {
         Iter { parent, green, offset, index: 0 }
     }
 
-    fn next(&mut self) -> Option<((&GreenElement, u32, TextUnit))> {
+    fn next(&mut self) -> Option<(&GreenElement, u32, TextUnit)> {
         self.green.next().map(|element| {
             let offset = self.offset;
             let index = self.index;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
-#![allow(unused)]
 
 mod green;
 #[allow(unsafe_code)]

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -1,8 +1,8 @@
-use std::{fmt, ops};
+use std::fmt;
 
 use crate::{
-    cursor::{SyntaxElement, SyntaxNode, SyntaxToken},
-    NodeOrToken, SmolStr, TextRange, TextUnit,
+    cursor::{SyntaxNode, SyntaxToken},
+    TextRange, TextUnit,
 };
 
 #[derive(Clone)]
@@ -191,7 +191,6 @@ fn zip_texts<I: Iterator<Item = (SyntaxToken, TextRange)>>(xs: &mut I, ys: &mut 
         x.1 = TextRange::from_to(x.1.start() + advance, x.1.end());
         y.1 = TextRange::from_to(y.1.start() + advance, y.1.end());
     }
-    None
 }
 
 impl Eq for SyntaxText {}

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,7 +1,3 @@
-use std::{iter, ops::Range};
-
-use crate::{TextRange, TextUnit};
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
     Node(N),


### PR DESCRIPTION
Piecewise improvement to replace the wholesale refactor that is #35.

Re-enables `#[warn(unused)]` and fixes the resulting fallout.