### PR TITLE
Hide green element storage mechanism in GreenNode::children

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.6.3"
+version = "0.7.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/matklad/rowan"
 license = "MIT OR Apache-2.0"

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -313,8 +313,8 @@ impl Atom {
         Some(op)
     }
     fn text(&self) -> &SmolStr {
-        match &self.0.green().children()[0] {
-            rowan::NodeOrToken::Token(token) => token.text(),
+        match &self.0.green().children().next() {
+            Some(rowan::NodeOrToken::Token(token)) => token.text(),
             _ => unreachable!(),
         }
     }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,6 +1,6 @@
-use super::*;
-
 use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
+
+use super::*;
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,12 +1,20 @@
-use super::*;
-
 use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
 
+use super::*;
+
 pub(crate) type GreenElement = NodeOrToken<GreenNode, GreenToken>;
+pub(crate) type GreenElementRef<'a> = NodeOrToken<&'a GreenNode, &'a GreenToken>;
 
 impl From<GreenNode> for GreenElement {
     #[inline]
     fn from(node: GreenNode) -> GreenElement {
+        NodeOrToken::Node(node)
+    }
+}
+
+impl<'a> From<&'a GreenNode> for GreenElementRef<'a> {
+    #[inline]
+    fn from(node: &'a GreenNode) -> GreenElementRef<'a> {
         NodeOrToken::Node(node)
     }
 }
@@ -18,7 +26,28 @@ impl From<GreenToken> for GreenElement {
     }
 }
 
+impl<'a> From<&'a GreenToken> for GreenElementRef<'a> {
+    #[inline]
+    fn from(token: &'a GreenToken) -> GreenElementRef<'a> {
+        NodeOrToken::Token(token)
+    }
+}
+
 impl GreenElement {
+    /// Returns kind of this element.
+    #[inline]
+    pub fn kind(&self) -> SyntaxKind {
+        self.as_ref().kind()
+    }
+
+    /// Returns length of the text covered by this element.
+    #[inline]
+    pub fn text_len(&self) -> TextUnit {
+        self.as_ref().text_len()
+    }
+}
+
+impl GreenElementRef<'_> {
     /// Returns kind of this element.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,7 +1,8 @@
-use super::*;
-use std::sync::Arc;
+use std::{slice, sync::Arc, iter::FusedIterator};
 
-use crate::{cursor::SyntaxKind, TextUnit};
+use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
+
+use super::*;
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
@@ -35,7 +36,93 @@ impl GreenNode {
 
     /// Children of this node.
     #[inline]
-    pub fn children(&self) -> &[GreenElement] {
-        &self.children
+    pub fn children(&self) -> Children<'_> {
+        Children { inner: self.children.iter() }
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct Children<'a> {
+    inner: slice::Iter<'a, GreenElement>,
+}
+
+// NB: forward everything stable that iter::Slice specializes as of Rust 1.39.0
+impl ExactSizeIterator for Children<'_> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.inner.len()
+    }
+}
+
+impl<'a> Iterator for Children<'a> {
+    type Item = GreenElementRef<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<GreenElementRef<'a>> {
+        self.inner.next().map(NodeOrToken::as_ref)
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.inner.size_hint()
+    }
+
+    #[inline]
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.inner.count()
+    }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth(n).map(NodeOrToken::as_ref)
+    }
+
+    #[inline]
+    fn last(mut self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        self.next_back()
+    }
+
+    #[inline]
+    fn fold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut accum = init;
+        while let Some(x) = self.next() {
+            accum = f(accum, x);
+        }
+        accum
+    }
+}
+
+impl<'a> DoubleEndedIterator for Children<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back().map(NodeOrToken::as_ref)
+    }
+
+    #[inline]
+    fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
+        self.inner.nth_back(n).map(NodeOrToken::as_ref)
+    }
+
+    #[inline]
+    fn rfold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    where
+        Fold: FnMut(Acc, Self::Item) -> Acc,
+    {
+        let mut accum = init;
+        while let Some(x) = self.next_back() {
+            accum = f(accum, x);
+        }
+        accum
+    }
+}
+
+impl FusedIterator for Children<'_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,8 @@ mod utility_types;
 #[cfg(feature = "serde1")]
 mod serde_impls;
 
-use green::GreenElement;
+#[allow(unused)]
+use green::{GreenElement, GreenElementRef};
 
 // Reexport types for working with strings. We might be too opinionated about
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
@@ -27,7 +28,7 @@ pub use text_unit::{TextRange, TextUnit};
 
 pub use crate::{
     api::*,
-    green::{Checkpoint, GreenNode, GreenNodeBuilder, GreenToken},
+    green::{Checkpoint, GreenNode, GreenNodeBuilder, GreenToken, Children},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -11,22 +11,41 @@ impl<N, T> NodeOrToken<N, T> {
             NodeOrToken::Token(_) => None,
         }
     }
+
     pub fn into_token(self) -> Option<T> {
         match self {
             NodeOrToken::Node(_) => None,
             NodeOrToken::Token(token) => Some(token),
         }
     }
+
     pub fn as_node(&self) -> Option<&N> {
         match self {
             NodeOrToken::Node(node) => Some(node),
             NodeOrToken::Token(_) => None,
         }
     }
+
     pub fn as_token(&self) -> Option<&T> {
         match self {
             NodeOrToken::Node(_) => None,
             NodeOrToken::Token(token) => Some(token),
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> NodeOrToken<&N, &T> {
+        match self {
+            NodeOrToken::Node(node) => NodeOrToken::Node(node),
+            NodeOrToken::Token(token) => NodeOrToken::Token(token),
+        }
+    }
+}
+
+impl<N: Clone, T: Clone> NodeOrToken<&N, &T> {
+    pub(crate) fn cloned(&self) -> NodeOrToken<N, T> {
+        match *self {
+            NodeOrToken::Node(node) => NodeOrToken::Node(node.clone()),
+            NodeOrToken::Token(token) => NodeOrToken::Token(token.clone()),
         }
     }
 }
@@ -83,6 +102,7 @@ impl<T> TokenAtOffset<T> {
             TokenAtOffset::Between(_, right) => Some(right),
         }
     }
+
     /// Convert to option, preferring the left leaf in case of a tie.
     pub fn left_biased(self) -> Option<T> {
         match self {


### PR DESCRIPTION
On top of #39. This is the main reason for splitting out new piecewise PRs, as this is the major breaking change required for changing the `GreenElement` internal packed representation from `enum NodeOrToken`.

r? @matklad 