### PR TITLE
Box and cache GreenToken

### DIFF
--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -2,6 +2,42 @@ use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 
 use super::*;
 
+#[derive(Default, Debug)]
+struct Cache {
+    nodes: rustc_hash::FxHashSet<GreenNode>,
+    tokens: rustc_hash::FxHashSet<GreenToken>,
+}
+
+impl Cache {
+    fn node(&mut self, kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+        let mut node = GreenNode::new(kind, children);
+        // Green nodes are fully immutable, so it's ok to deduplicate them.
+        // This is the same optimization that Roslyn does
+        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
+        //
+        // For example, all `#[inline]` in this file share the same green node!
+        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
+        // 17% of the memory for green nodes!
+        // Future work: make hashing faster by avoiding rehashing of subtrees.
+        if node.children.len() <= 3 {
+            match self.nodes.get(&node) {
+                Some(existing) => node = existing.clone(),
+                None => assert!(self.nodes.insert(node.clone())),
+            }
+        }
+        node
+    }
+
+    fn token(&mut self, kind: SyntaxKind, text: SmolStr) -> GreenToken {
+        let mut token = GreenToken::new(kind, text);
+        match self.tokens.get(&token) {
+            Some(existing) => token = existing.clone(),
+            None => assert!(self.tokens.insert(token.clone())),
+        }
+        token
+    }
+}
+
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]
 pub struct Checkpoint(usize);
@@ -9,7 +45,7 @@ pub struct Checkpoint(usize);
 /// A builder for a green tree.
 #[derive(Default, Debug)]
 pub struct GreenNodeBuilder {
-    cache: rustc_hash::FxHashSet<GreenNode>,
+    cache: Cache,
     parents: Vec<(SyntaxKind, usize)>,
     children: Vec<GreenElement>,
 }
@@ -24,7 +60,7 @@ impl GreenNodeBuilder {
     /// Adds new token to the current branch.
     #[inline]
     pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {
-        let token = GreenToken { kind, text };
+        let token = self.cache.token(kind, text);
         self.children.push(token.into());
     }
 
@@ -41,21 +77,7 @@ impl GreenNodeBuilder {
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
         let children: Vec<_> = self.children.drain(first_child..).collect();
-        let mut node = GreenNode::new(kind, children.into_boxed_slice());
-        // Green nodes are fully immutable, so it's ok to deduplicate them.
-        // This is the same optimization that Roslyn does
-        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
-        //
-        // For example, all `#[inline]` in this file share the same green node!
-        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
-        // 17% of the memory for green nodes!
-        // Future work: make hashing faster by avoiding rehashing of subtrees.
-        if node.children.len() <= 3 {
-            match self.cache.get(&node) {
-                Some(existing) => node = existing.clone(),
-                None => assert!(self.cache.insert(node.clone())),
-            }
-        }
+        let node = self.cache.node(kind, children.into_boxed_slice());
         self.children.push(node.into());
     }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,34 +1,41 @@
+use std::sync::Arc;
+
 use crate::{cursor::SyntaxKind, SmolStr, TextUnit};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct GreenTokenData {
+    kind: SyntaxKind,
+    text: SmolStr,
+}
 
 /// Leaf node in the immutable tree.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GreenToken {
-    pub(super) kind: SyntaxKind,
-    pub(super) text: SmolStr,
+    data: Arc<GreenTokenData>,
 }
 
 impl GreenToken {
     /// Creates new Token.
     #[inline]
     pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
-        GreenToken { kind, text }
+        GreenToken { data: Arc::new(GreenTokenData { kind, text }) }
     }
 
     /// Kind of this Token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.kind
+        self.data.kind
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &SmolStr {
-        &self.text
+        &self.data.text
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        TextUnit::from_usize(self.text.len())
+        TextUnit::from_usize(self.text().len())
     }
 }


### PR DESCRIPTION
This uses an inner `Arc` to decrease the size of `GreenToken`. This uses the same caching logic as `GreenNode` through `GreenNodeBuilder`. Do note that this means that to get a decently memory-thoughtful tree, either the use of `GreenNodeBuilder` or a manual cache in the same style is required. We should probably consider eventually exposing some version of the `Cache` implemented here, such that bottom-up builders can use it and get the deduplication for free.

The main reason for shrinking `GreenToken` is the target of shrinking `GreenElement`, as each node carries a `[GreenElement]`, and by reducing overhead per-element, we can considerably decrease overall memory usage. By boxing `GreenToken` we make room to shrink `GreenNode` and benefit from said shrinkage.

r? @matklad 

<details><summary>Size comparison</summary>

Before:

```
GreenNode    24
GreenToken   32
GreenElement 40

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```

After:

```
GreenNode    24
GreenToken   8
GreenElement 32

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```