### PR TITLE
Use thin-dst in GreenNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ rustc-hash = "1.0.1"
 text_unit = "0.1.6"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
+thin-dst = "1.0.0"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -19,7 +19,7 @@ impl Cache {
         // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
         // 17% of the memory for green nodes!
         // Future work: make hashing faster by avoiding rehashing of subtrees.
-        if node.children.len() <= 3 {
+        if node.children().len() <= 3 {
             match self.nodes.get(&node) {
                 Some(existing) => node = existing.clone(),
                 None => assert!(self.nodes.insert(node.clone())),

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -2,6 +2,42 @@ use crate::{cursor::SyntaxKind, NodeOrToken, SmolStr};
 
 use super::*;
 
+#[derive(Default, Debug)]
+struct Cache {
+    nodes: rustc_hash::FxHashSet<GreenNode>,
+    tokens: rustc_hash::FxHashSet<GreenToken>,
+}
+
+impl Cache {
+    fn node(&mut self, kind: SyntaxKind, children: Box<[GreenElement]>) -> GreenNode {
+        let mut node = GreenNode::new(kind, children);
+        // Green nodes are fully immutable, so it's ok to deduplicate them.
+        // This is the same optimization that Roslyn does
+        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
+        //
+        // For example, all `#[inline]` in this file share the same green node!
+        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
+        // 17% of the memory for green nodes!
+        // Future work: make hashing faster by avoiding rehashing of subtrees.
+        if node.children.len() <= 3 {
+            match self.nodes.get(&node) {
+                Some(existing) => node = existing.clone(),
+                None => assert!(self.nodes.insert(node.clone())),
+            }
+        }
+        node
+    }
+
+    fn token(&mut self, kind: SyntaxKind, text: SmolStr) -> GreenToken {
+        let mut token = GreenToken::new(kind, text);
+        match self.tokens.get(&token) {
+            Some(existing) => token = existing.clone(),
+            None => assert!(self.tokens.insert(token.clone())),
+        }
+        token
+    }
+}
+
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.
 #[derive(Clone, Copy, Debug)]
 pub struct Checkpoint(usize);
@@ -9,7 +45,7 @@ pub struct Checkpoint(usize);
 /// A builder for a green tree.
 #[derive(Default, Debug)]
 pub struct GreenNodeBuilder {
-    cache: rustc_hash::FxHashSet<GreenNode>,
+    cache: Cache,
     parents: Vec<(SyntaxKind, usize)>,
     children: Vec<GreenElement>,
 }
@@ -24,7 +60,7 @@ impl GreenNodeBuilder {
     /// Adds new token to the current branch.
     #[inline]
     pub fn token(&mut self, kind: SyntaxKind, text: SmolStr) {
-        let token = GreenToken { kind, text };
+        let token = self.cache.token(kind, text);
         self.children.push(token.into());
     }
 
@@ -41,21 +77,7 @@ impl GreenNodeBuilder {
     pub fn finish_node(&mut self) {
         let (kind, first_child) = self.parents.pop().unwrap();
         let children: Vec<_> = self.children.drain(first_child..).collect();
-        let mut node = GreenNode::new(kind, children.into_boxed_slice());
-        // Green nodes are fully immutable, so it's ok to deduplicate them.
-        // This is the same optimization that Roslyn does
-        // https://github.com/KirillOsenkov/Bliki/wiki/Roslyn-Immutable-Trees
-        //
-        // For example, all `#[inline]` in this file share the same green node!
-        // For `libsyntax/parse/parser.rs`, measurements show that deduping saves
-        // 17% of the memory for green nodes!
-        // Future work: make hashing faster by avoiding rehashing of subtrees.
-        if node.children.len() <= 3 {
-            match self.cache.get(&node) {
-                Some(existing) => node = existing.clone(),
-                None => assert!(self.cache.insert(node.clone())),
-            }
-        }
+        let node = self.cache.node(kind, children.into_boxed_slice());
         self.children.push(node.into());
     }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,34 +1,41 @@
+use std::sync::Arc;
+
 use crate::{cursor::SyntaxKind, SmolStr, TextUnit};
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct GreenTokenData {
+    kind: SyntaxKind,
+    text: SmolStr,
+}
 
 /// Leaf node in the immutable tree.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GreenToken {
-    pub(super) kind: SyntaxKind,
-    pub(super) text: SmolStr,
+    data: Arc<GreenTokenData>,
 }
 
 impl GreenToken {
     /// Creates new Token.
     #[inline]
     pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
-        GreenToken { kind, text }
+        GreenToken { data: Arc::new(GreenTokenData { kind, text }) }
     }
 
     /// Kind of this Token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.kind
+        self.data.kind
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &SmolStr {
-        &self.text
+        &self.data.text
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
-        TextUnit::from_usize(self.text.len())
+        TextUnit::from_usize(self.text().len())
     }
 }


### PR DESCRIPTION
On top of #41. (Theoretically disjoint, but no size benefit without.)

Uses [thin-dst](https://github.com/cad97/thin-dst) to store `GreenNode`'s `kind`, `text_len`, and `children` all inline in a single allocation, behind a thin pointer.

`GreenElement` can theoretically be further squished from 2×usize to 1×usize by using alignment bits to tag whether the pointer is a node or a token. That will be proposed in a follow-up PR.

r? @matklad 

<details><summary>Size comparison</summary>

Before:

```
GreenNode    24
GreenToken   8
GreenElement 32

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```

After:

```
GreenNode    8
GreenToken   8
GreenElement 16

SyntaxNode    8
SyntaxToken   16
SyntaxElement 24
```