### PR TITLE
Pack GreenElement into 1×usize PackedGreenElement

### DIFF
--- a/src/green.rs
+++ b/src/green.rs
@@ -3,5 +3,5 @@ mod token;
 mod element;
 mod builder;
 
-pub(crate) use self::element::*;
+pub(crate) use self::{element::*, node::*, token::*};
 pub use self::{builder::*, node::*, token::*};

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,9 +1,17 @@
+use std::{fmt, hash, mem};
+
+use thin_dst::ErasedPtr;
+
 use crate::{cursor::SyntaxKind, NodeOrToken, TextUnit};
 
 use super::*;
 
 pub(crate) type GreenElement = NodeOrToken<GreenNode, GreenToken>;
 pub(crate) type GreenElementRef<'a> = NodeOrToken<&'a GreenNode, &'a GreenToken>;
+#[repr(transparent)]
+pub(crate) struct PackedGreenElement {
+    ptr: ErasedPtr,
+}
 
 impl From<GreenNode> for GreenElement {
     #[inline]
@@ -19,6 +27,13 @@ impl<'a> From<&'a GreenNode> for GreenElementRef<'a> {
     }
 }
 
+impl From<GreenNode> for PackedGreenElement {
+    #[inline]
+    fn from(node: GreenNode) -> PackedGreenElement {
+        unsafe { mem::transmute(node) }
+    }
+}
+
 impl From<GreenToken> for GreenElement {
     #[inline]
     fn from(token: GreenToken) -> GreenElement {
@@ -30,6 +45,13 @@ impl<'a> From<&'a GreenToken> for GreenElementRef<'a> {
     #[inline]
     fn from(token: &'a GreenToken) -> GreenElementRef<'a> {
         NodeOrToken::Token(token)
+    }
+}
+
+impl From<GreenToken> for PackedGreenElement {
+    #[inline]
+    fn from(token: GreenToken) -> PackedGreenElement {
+        unsafe { mem::transmute(token) }
     }
 }
 
@@ -65,4 +87,122 @@ impl GreenElementRef<'_> {
             NodeOrToken::Token(it) => it.text_len(),
         }
     }
+}
+
+impl From<GreenElement> for PackedGreenElement {
+    fn from(element: GreenElement) -> Self {
+        match element {
+            NodeOrToken::Node(node) => node.into(),
+            NodeOrToken::Token(token) => token.into(),
+        }
+    }
+}
+
+impl From<PackedGreenElement> for GreenElement {
+    fn from(element: PackedGreenElement) -> Self {
+        if element.is_node() {
+            NodeOrToken::Node(element.into_node().unwrap())
+        } else {
+            NodeOrToken::Token(element.into_token().unwrap())
+        }
+    }
+}
+
+impl PackedGreenElement {
+    fn is_node(&self) -> bool {
+        self.ptr.as_ptr() as usize & 1 == 0
+    }
+
+    pub(crate) fn as_node(&self) -> Option<&GreenNode> {
+        if self.is_node() {
+            unsafe { Some(&*(&self.ptr as *const ErasedPtr as *const GreenNode)) }
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn into_node(self) -> Option<GreenNode> {
+        if self.is_node() {
+            unsafe { Some(mem::transmute(self)) }
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_token(&self) -> Option<&GreenToken> {
+        if !self.is_node() {
+            unsafe { Some(&*(&self.ptr as *const ErasedPtr as *const GreenToken)) }
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn into_token(self) -> Option<GreenToken> {
+        if !self.is_node() {
+            unsafe { Some(mem::transmute(self)) }
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn as_ref(&self) -> GreenElementRef<'_> {
+        if self.is_node() {
+            NodeOrToken::Node(self.as_node().unwrap())
+        } else {
+            NodeOrToken::Token(self.as_token().unwrap())
+        }
+    }
+}
+
+impl fmt::Debug for PackedGreenElement {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_node() {
+            self.as_node().unwrap().fmt(f)
+        } else {
+            self.as_token().unwrap().fmt(f)
+        }
+    }
+}
+
+impl Eq for PackedGreenElement {}
+impl PartialEq for PackedGreenElement {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_node() == other.as_node() && self.as_token() == other.as_token()
+    }
+}
+
+impl hash::Hash for PackedGreenElement {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: hash::Hasher,
+    {
+        if self.is_node() {
+            self.as_node().unwrap().hash(state)
+        } else {
+            self.as_token().unwrap().hash(state)
+        }
+    }
+}
+
+impl Drop for PackedGreenElement {
+    fn drop(&mut self) {
+        if self.is_node() {
+            PackedGreenElement { ptr: self.ptr }.into_node();
+        } else {
+            PackedGreenElement { ptr: self.ptr }.into_token();
+        }
+    }
+}
+
+unsafe impl Send for PackedGreenElement
+where
+    GreenToken: Send,
+    GreenNode: Send,
+{
+}
+unsafe impl Sync for PackedGreenElement
+where
+    GreenToken: Sync,
+    GreenNode: Sync,
+{
 }

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -11,7 +11,7 @@ pub(crate) struct GreenTokenData {
 
 /// Leaf node in the immutable tree.
 pub struct GreenToken {
-    ptr: ptr::NonNull<GreenTokenData>,
+    pub(super) ptr: ptr::NonNull<GreenTokenData>,
 }
 
 unsafe impl Send for GreenToken {} // where GreenTokenData: Send + Sync

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,41 +1,104 @@
-use std::sync::Arc;
+use std::{fmt, hash, mem::ManuallyDrop, ptr, sync::Arc};
 
 use crate::{cursor::SyntaxKind, SmolStr, TextUnit};
 
+#[repr(align(2))] // NB: this is an at-least annotation
 #[derive(Debug, PartialEq, Eq, Hash)]
-struct GreenTokenData {
+pub(crate) struct GreenTokenData {
     kind: SyntaxKind,
     text: SmolStr,
 }
 
 /// Leaf node in the immutable tree.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct GreenToken {
-    data: Arc<GreenTokenData>,
+    ptr: ptr::NonNull<GreenTokenData>,
 }
 
+unsafe impl Send for GreenToken {} // where GreenTokenData: Send + Sync
+unsafe impl Sync for GreenToken {} // where GreenTokenData: Send + Sync
+
 impl GreenToken {
+    fn add_tag(ptr: ptr::NonNull<GreenTokenData>) -> ptr::NonNull<GreenTokenData> {
+        unsafe {
+            let ptr = ((ptr.as_ptr() as usize) | 1) as *mut GreenTokenData;
+            ptr::NonNull::new_unchecked(ptr)
+        }
+    }
+
+    fn remove_tag(ptr: ptr::NonNull<GreenTokenData>) -> ptr::NonNull<GreenTokenData> {
+        unsafe {
+            let ptr = ((ptr.as_ptr() as usize) & !1) as *mut GreenTokenData;
+            ptr::NonNull::new_unchecked(ptr)
+        }
+    }
+
+    fn data(&self) -> &GreenTokenData {
+        unsafe { &*Self::remove_tag(self.ptr).as_ptr() }
+    }
+
     /// Creates new Token.
     #[inline]
     pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
-        GreenToken { data: Arc::new(GreenTokenData { kind, text }) }
+        let ptr = Arc::into_raw(Arc::new(GreenTokenData { kind, text }));
+        let ptr = ptr::NonNull::new(ptr as *mut _).unwrap();
+        GreenToken { ptr: Self::add_tag(ptr) }
     }
 
     /// Kind of this Token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.data.kind
+        self.data().kind
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &SmolStr {
-        &self.data.text
+        &self.data().text
     }
 
     /// Text of this Token.
     #[inline]
     pub fn text_len(&self) -> TextUnit {
         TextUnit::from_usize(self.text().len())
+    }
+}
+
+impl fmt::Debug for GreenToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let data = self.data();
+        f.debug_struct("GreenToken").field("kind", &data.kind).field("text", &data.text).finish()
+    }
+}
+
+impl Clone for GreenToken {
+    fn clone(&self) -> Self {
+        let ptr = Self::remove_tag(self.ptr);
+        let ptr = unsafe {
+            let arc = ManuallyDrop::new(Arc::from_raw(ptr.as_ptr()));
+            Arc::into_raw(Arc::clone(&arc))
+        };
+        let ptr = ptr::NonNull::new(ptr as *mut _).unwrap();
+        GreenToken { ptr: Self::add_tag(ptr) }
+    }
+}
+
+impl Eq for GreenToken {}
+impl PartialEq for GreenToken {
+    fn eq(&self, other: &Self) -> bool {
+        self.data() == other.data()
+    }
+}
+
+impl hash::Hash for GreenToken {
+    fn hash<H>(&self, state: &mut H) where H: hash::Hasher {
+        self.data().hash(state)
+    }
+}
+
+impl Drop for GreenToken {
+    fn drop(&mut self) {
+        unsafe {
+            Arc::from_raw(Self::remove_tag(self.ptr).as_ptr());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 )]
 #![deny(unsafe_code)]
 
+#[allow(unsafe_code)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;
@@ -41,6 +42,9 @@ mod tests {
     fn assert_send_sync() {
         fn f<T: Send + Sync>() {}
         f::<GreenNode>();
+        f::<GreenToken>();
+        f::<GreenElement>();
+        f::<green::GreenTokenData>();
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod utility_types;
 mod serde_impls;
 
 #[allow(unused)]
-use green::{GreenElement, GreenElementRef};
+use green::{GreenElement, GreenElementRef, PackedGreenElement};
 
 // Reexport types for working with strings. We might be too opinionated about
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
@@ -29,7 +29,7 @@ pub use text_unit::{TextRange, TextUnit};
 
 pub use crate::{
     api::*,
-    green::{Checkpoint, GreenNode, GreenNodeBuilder, GreenToken, Children},
+    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };
@@ -44,6 +44,7 @@ mod tests {
         f::<GreenNode>();
         f::<GreenToken>();
         f::<GreenElement>();
+        f::<PackedGreenElement>();
         f::<green::GreenTokenData>();
     }
 
@@ -51,9 +52,10 @@ mod tests {
     fn test_size_of() {
         use std::mem::size_of;
 
-        eprintln!("GreenNode    {}", size_of::<GreenNode>());
-        eprintln!("GreenToken   {}", size_of::<GreenToken>());
-        eprintln!("GreenElement {}", size_of::<GreenElement>());
+        eprintln!("GreenNode          {}", size_of::<GreenNode>());
+        eprintln!("GreenToken         {}", size_of::<GreenToken>());
+        eprintln!("GreenElement       {}", size_of::<GreenElement>());
+        eprintln!("PackedGreenElement {}", size_of::<PackedGreenElement>());
         eprintln!();
         eprintln!("SyntaxNode    {}", size_of::<cursor::SyntaxNode>());
         eprintln!("SyntaxToken   {}", size_of::<cursor::SyntaxToken>());


### PR DESCRIPTION
r? @matklad 

It is required here to tag _all_ `GreenToken` to have a low bit of `1` so that we can go from `&PackedGreenElement` to `GreenElementRef`.