### PR TITLE
Rename serde feature flag to `serde`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,18 @@ edition = "2018"
 rustc-hash = "1.0.1"
 text-size = "1.0.0"
 smol_str = "0.1.10"
-serde = { version = "1.0.89", optional = true, default-features = false }
 thin-dst = "1.0.0"
+
+[dependencies.serde_] # renamed so feature flag can be "serde"
+package = "serde"
+version = "1.0.89"
+optional = true
+default-features = false
 
 [dev-dependencies]
 m_lexer = "0.0.4"
 
 [features]
-serde1 = [ "serde", "text-size/serde" ]
+serde = ["serde_", "text-size/serde"]
+
+serde1 = [ "serde" ] # deprecated alias for feature "serde"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub mod cursor;
 pub mod api;
 mod syntax_text;
 mod utility_types;
-#[cfg(feature = "serde1")]
+#[cfg(feature = "serde")]
 mod serde_impls;
 
 // Reexport types for working with strings. We might be too opinionated about

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,4 +1,4 @@
-use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
+use serde_::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{


### PR DESCRIPTION
The `serde1` feature flag should be removed with the next version bump.

(I'm working on a proof of implementing rowan's green tree by wrapping sorbus's green tree, so that will probably be the next version bump.)