### PR TITLE
Use sorbus internally as the green tree implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,19 @@
 [package]
 name = "rowan"
-version = "0.10.0"
-authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
+version = "0.11.0"
+authors = [
+    "Aleksey Kladov <aleksey.kladov@gmail.com>",
+    "Christopher Durham (CAD97) <cad97@cad97.com>",
+]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
 edition = "2018"
 
 [dependencies]
-rustc-hash = "1.0.1"
 text-size = "1.0.0"
-smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
-thin-dst = "1.0.0"
+sorbus = { git = "https://github.com/CAD97/sorbus.git" }
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,11 @@ description = "Library for generic lossless syntax trees"
 edition = "2018"
 
 [dependencies]
-text-size = "1.0.0"
+text-size = "1.0.0" # public
 serde = { version = "1.0.89", optional = true, default-features = false }
-sorbus = { git = "https://github.com/CAD97/sorbus.git" }
-erasable = "1.2.0"
+rc-borrow = "1.2.0" # public
+sorbus = { git = "https://github.com/CAD97/sorbus.git" } # private
+erasable = "1.2.0" # private
 
 [dev-dependencies]
 smol_str = "0.1.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,10 @@ edition = "2018"
 text-size = "1.0.0"
 serde = { version = "1.0.89", optional = true, default-features = false }
 sorbus = { git = "https://github.com/CAD97/sorbus.git" }
+erasable = "1.2.0"
 
 [dev-dependencies]
+smol_str = "0.1.10"
 m_lexer = "0.0.4"
 
 [features]

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -13,7 +13,8 @@
 //!     - "+" Token(Add)
 //!     - "4" Token(Number)
 
-use rowan::{GreenNodeBuilder, NodeOrToken, SmolStr};
+use rowan::{GreenNodeBuilder, NodeOrToken};
+use smol_str::SmolStr;
 use std::iter::Peekable;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -72,7 +73,7 @@ impl<I: Iterator<Item = (SyntaxKind, SmolStr)>> Parser<I> {
     }
     fn bump(&mut self) {
         if let Some((token, string)) = self.iter.next() {
-            self.builder.token(token.into(), string);
+            self.builder.token(token.into(), &string);
         }
     }
     fn parse_val(&mut self) {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -9,13 +9,13 @@
 //! alongside this tutorial:
 //! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
 
+// misc. imports to make sorbus port easier
+use smol_str::SmolStr;
+use std::sync::Arc;
+use rowan::ArcBorrow;
 
-/// Currently, rowan doesn't have a hook to add your own interner,
-/// but `SmolStr` should be a "good enough" type for representing
-/// tokens.
-/// Additionally, rowan uses `TextSize` and `TextRange` types to
+/// Rowan uses `TextSize` and `TextRange` types to
 /// represent utf8 offsets and ranges.
-use rowan::SmolStr;
 
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.
@@ -75,7 +75,7 @@ use rowan::GreenNodeBuilder;
 /// The parse results are stored as a "green tree".
 /// We'll discuss working with the results later
 struct Parse {
-    green_node: GreenNode,
+    green_node: Arc<GreenNode>,
     #[allow(unused)]
     errors: Vec<String>,
 }
@@ -177,7 +177,7 @@ fn parse(text: &str) -> Parse {
         /// Advance one token, adding it to the current branch of the tree builder.
         fn bump(&mut self) {
             let (kind, text) = self.tokens.pop().unwrap();
-            self.builder.token(kind.into(), text);
+            self.builder.token(kind.into(), &text);
         }
         /// Peek at the first unprocessed token
         fn current(&self) -> Option<SyntaxKind> {
@@ -324,7 +324,7 @@ impl Atom {
         self.text().parse().ok()
     }
     fn as_op(&self) -> Option<Op> {
-        let op = match self.text().as_str() {
+        let op = match self.text() {
             "+" => Op::Add,
             "-" => Op::Sub,
             "*" => Op::Mul,
@@ -333,9 +333,9 @@ impl Atom {
         };
         Some(op)
     }
-    fn text(&self) -> &SmolStr {
-        match &self.0.green().children().next() {
-            Some(rowan::NodeOrToken::Token(token)) => token.text(),
+    fn text(&self) -> &str {
+        match self.0.green().children().next() {
+            Some(rowan::NodeOrToken::Token(token)) => ArcBorrow::downgrade(token).text(),
             _ => unreachable!(),
         }
     }

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -334,7 +334,8 @@ impl Atom {
         Some(op)
     }
     fn text(&self) -> &str {
-        match self.0.green().children().next() {
+        let green = self.0.green();
+        match ArcBorrow::downgrade(green).children().next() {
             Some(rowan::NodeOrToken::Token(token)) => ArcBorrow::downgrade(token).text(),
             _ => unreachable!(),
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -383,3 +383,27 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
         self.raw.next().map(NodeOrToken::from)
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SyntaxNodePtr<L: Language> {
+    pub raw: cursor::SyntaxNodePtr,
+    _p: PhantomData<L>,
+}
+
+impl<L: Language> SyntaxNodePtr<L> {
+    pub fn kind(&self) -> L::Kind {
+        L::kind_from_raw(self.raw.kind)
+    }
+
+    pub fn text_range(&self) -> TextRange {
+        self.raw.text_range
+    }
+
+    pub fn new(node: &SyntaxNode<L>) -> SyntaxNodePtr<L> {
+        SyntaxNodePtr { raw: cursor::SyntaxNodePtr::new(&node.raw), _p: PhantomData }
+    }
+
+    pub fn resolve(&self, root: &SyntaxNode<L>) -> SyntaxNode<L> {
+        self.raw.resolve(&root.raw).into()
+    }
+}

--- a/src/api.rs
+++ b/src/api.rs
@@ -165,8 +165,8 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.text()
     }
 
-    pub fn green(&self) -> &GreenNode {
-        ArcBorrow::downgrade(self.raw.green())
+    pub fn green(&self) -> ArcBorrow<'_, GreenNode> {
+        self.raw.green()
     }
 
     pub fn parent(&self) -> Option<SyntaxNode<L>> {

--- a/src/green.rs
+++ b/src/green.rs
@@ -3,9 +3,7 @@ mod token;
 mod element;
 mod builder;
 
-pub(crate) use self::element::GreenElementRef;
-use self::element::{GreenElement, PackedGreenElement};
-
+pub(crate) use self::element::{GreenElement, GreenElementRef};
 pub use self::{
     builder::{Checkpoint, GreenNodeBuilder, NodeCache},
     node::{Children, GreenNode},
@@ -15,27 +13,3 @@ pub use self::{
 /// SyntaxKind is a type tag for each token or node.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SyntaxKind(pub u16);
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn assert_send_sync() {
-        fn f<T: Send + Sync>() {}
-        f::<GreenNode>();
-        f::<GreenToken>();
-        f::<GreenElement>();
-        f::<PackedGreenElement>();
-    }
-
-    #[test]
-    fn test_size_of() {
-        use std::mem::size_of;
-
-        eprintln!("GreenNode          {}", size_of::<GreenNode>());
-        eprintln!("GreenToken         {}", size_of::<GreenToken>());
-        eprintln!("GreenElement       {}", size_of::<GreenElement>());
-        eprintln!("PackedGreenElement {}", size_of::<PackedGreenElement>());
-    }
-}

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,59 +1,54 @@
-use std::{fmt, hash, mem};
-
-use thin_dst::ErasedPtr;
-
-use crate::{
-    green::{GreenNode, GreenToken, SyntaxKind},
-    NodeOrToken, TextSize,
+use {
+    crate::{
+        green::{GreenNode, GreenToken, SyntaxKind},
+        NodeOrToken, TextSize,
+    },
+    std::sync::Arc,
+    sorbus::ArcBorrow,
 };
 
-pub(super) type GreenElement = NodeOrToken<GreenNode, GreenToken>;
-pub(crate) type GreenElementRef<'a> = NodeOrToken<&'a GreenNode, &'a GreenToken>;
+pub(crate) type GreenElement = NodeOrToken<Arc<GreenNode>, Arc<GreenToken>>;
+pub(crate) type GreenElementRef<'a> = NodeOrToken<ArcBorrow<'a, GreenNode>, ArcBorrow<'a, GreenToken>>;
 
-#[repr(transparent)]
-pub(super) struct PackedGreenElement {
-    ptr: ErasedPtr,
-}
-
-impl From<GreenNode> for GreenElement {
+impl From<Arc<GreenNode>> for GreenElement {
     #[inline]
-    fn from(node: GreenNode) -> GreenElement {
+    fn from(node: Arc<GreenNode>) -> GreenElement {
         NodeOrToken::Node(node)
     }
 }
 
-impl<'a> From<&'a GreenNode> for GreenElementRef<'a> {
+impl<'a> From<&'a Arc<GreenNode>> for GreenElementRef<'a> {
     #[inline]
-    fn from(node: &'a GreenNode) -> GreenElementRef<'a> {
+    fn from(node: &'a Arc<GreenNode>) -> GreenElementRef<'a> {
+        NodeOrToken::Node(node.into())
+    }
+}
+
+impl<'a> From<ArcBorrow<'a, GreenNode>> for GreenElementRef<'a> {
+    #[inline]
+    fn from(node: ArcBorrow<'a, GreenNode>) -> GreenElementRef<'a> {
         NodeOrToken::Node(node)
     }
 }
 
-impl From<GreenNode> for PackedGreenElement {
+impl From<Arc<GreenToken>> for GreenElement {
     #[inline]
-    fn from(node: GreenNode) -> PackedGreenElement {
-        unsafe { mem::transmute(node) }
-    }
-}
-
-impl From<GreenToken> for GreenElement {
-    #[inline]
-    fn from(token: GreenToken) -> GreenElement {
+    fn from(token: Arc<GreenToken>) -> GreenElement {
         NodeOrToken::Token(token)
     }
 }
 
-impl<'a> From<&'a GreenToken> for GreenElementRef<'a> {
+impl<'a> From<&'a Arc<GreenToken>> for GreenElementRef<'a> {
     #[inline]
-    fn from(token: &'a GreenToken) -> GreenElementRef<'a> {
-        NodeOrToken::Token(token)
+    fn from(token: &'a Arc<GreenToken>) -> GreenElementRef<'a> {
+        NodeOrToken::Token(token.into())
     }
 }
 
-impl From<GreenToken> for PackedGreenElement {
+impl<'a> From<ArcBorrow<'a, GreenToken>> for GreenElementRef<'a> {
     #[inline]
-    fn from(token: GreenToken) -> PackedGreenElement {
-        unsafe { mem::transmute(token) }
+    fn from(token: ArcBorrow<'a, GreenToken>) -> GreenElementRef<'a> {
+        NodeOrToken::Token(token)
     }
 }
 
@@ -61,20 +56,20 @@ impl GreenElement {
     /// Returns kind of this element.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.as_ref().kind()
+        self.borrowed().kind()
     }
 
     /// Returns the length of the text covered by this element.
     #[inline]
     pub fn text_len(&self) -> TextSize {
-        self.as_ref().text_len()
+        self.borrowed().text_len()
     }
 }
 
 impl GreenElementRef<'_> {
     /// Returns kind of this element.
     #[inline]
-    pub fn kind(&self) -> SyntaxKind {
+    pub fn kind(self) -> SyntaxKind {
         match self {
             NodeOrToken::Node(it) => it.kind(),
             NodeOrToken::Token(it) => it.kind(),
@@ -89,122 +84,4 @@ impl GreenElementRef<'_> {
             NodeOrToken::Token(it) => it.text_len(),
         }
     }
-}
-
-impl From<GreenElement> for PackedGreenElement {
-    fn from(element: GreenElement) -> Self {
-        match element {
-            NodeOrToken::Node(node) => node.into(),
-            NodeOrToken::Token(token) => token.into(),
-        }
-    }
-}
-
-impl From<PackedGreenElement> for GreenElement {
-    fn from(element: PackedGreenElement) -> Self {
-        if element.is_node() {
-            NodeOrToken::Node(element.into_node().unwrap())
-        } else {
-            NodeOrToken::Token(element.into_token().unwrap())
-        }
-    }
-}
-
-impl PackedGreenElement {
-    fn is_node(&self) -> bool {
-        self.ptr.as_ptr() as usize & 1 == 0
-    }
-
-    pub(crate) fn as_node(&self) -> Option<&GreenNode> {
-        if self.is_node() {
-            unsafe { Some(&*(&self.ptr as *const ErasedPtr as *const GreenNode)) }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn into_node(self) -> Option<GreenNode> {
-        if self.is_node() {
-            unsafe { Some(mem::transmute(self)) }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn as_token(&self) -> Option<&GreenToken> {
-        if !self.is_node() {
-            unsafe { Some(&*(&self.ptr as *const ErasedPtr as *const GreenToken)) }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn into_token(self) -> Option<GreenToken> {
-        if !self.is_node() {
-            unsafe { Some(mem::transmute(self)) }
-        } else {
-            None
-        }
-    }
-
-    pub(crate) fn as_ref(&self) -> GreenElementRef<'_> {
-        if self.is_node() {
-            NodeOrToken::Node(self.as_node().unwrap())
-        } else {
-            NodeOrToken::Token(self.as_token().unwrap())
-        }
-    }
-}
-
-impl fmt::Debug for PackedGreenElement {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_node() {
-            self.as_node().unwrap().fmt(f)
-        } else {
-            self.as_token().unwrap().fmt(f)
-        }
-    }
-}
-
-impl Eq for PackedGreenElement {}
-impl PartialEq for PackedGreenElement {
-    fn eq(&self, other: &Self) -> bool {
-        self.as_node() == other.as_node() && self.as_token() == other.as_token()
-    }
-}
-
-impl hash::Hash for PackedGreenElement {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: hash::Hasher,
-    {
-        if self.is_node() {
-            self.as_node().unwrap().hash(state)
-        } else {
-            self.as_token().unwrap().hash(state)
-        }
-    }
-}
-
-impl Drop for PackedGreenElement {
-    fn drop(&mut self) {
-        if self.is_node() {
-            PackedGreenElement { ptr: self.ptr }.into_node();
-        } else {
-            PackedGreenElement { ptr: self.ptr }.into_token();
-        }
-    }
-}
-
-unsafe impl Send for PackedGreenElement
-where
-    GreenToken: Send,
-    GreenNode: Send,
-{
-}
-unsafe impl Sync for PackedGreenElement
-where
-    GreenToken: Sync,
-    GreenNode: Sync,
-{
 }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -53,6 +53,18 @@ impl GreenNode {
     pub fn children(&self) -> Children<'_> {
         Children { imp: self.imp.children() }
     }
+
+    pub(crate) fn child_by_offset(
+        &self,
+        offset: TextSize,
+    ) -> Option<(usize, TextSize, ArcBorrow<'_, GreenNode>)> {
+        if offset > self.text_len() {
+            return None;
+        }
+        let (index, offset, node) = self.imp.child_with_offset(offset);
+        let node = *node.as_node()?;
+        unsafe { Some((index, offset, mem::transmute(node))) }
+    }
 }
 
 #[derive(Clone)]

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -61,7 +61,8 @@ impl GreenNode {
         if offset > self.text_len() {
             return None;
         }
-        let (index, offset, node) = self.imp.child_with_offset(offset);
+        let index = self.imp.index_of_offset(offset);
+        let (offset, node) = self.imp.children().with_offsets().get(index)?;
         let node = *node.as_node()?;
         unsafe { Some((index, offset, mem::transmute(node))) }
     }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,83 +1,87 @@
-use std::{iter::FusedIterator, slice, sync::Arc};
-
-use thin_dst::{ThinArc, ThinData};
-
-use crate::{
-    green::{GreenElement, GreenElementRef, PackedGreenElement, SyntaxKind},
-    TextSize,
+use {
+    crate::{
+        green::{GreenElement, GreenElementRef, NodeCache, SyntaxKind},
+        ArcBorrow, NodeOrToken, TextSize,
+    },
+    std::{fmt, iter::FusedIterator, mem, sync::Arc},
 };
-
-#[repr(align(2))] // NB: this is an at-least annotation
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(super) struct GreenNodeHead {
-    kind: SyntaxKind,
-    text_len: TextSize,
-}
 
 /// Internal node in the immutable tree.
 /// It has other nodes and tokens as children.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+#[derive(Eq, PartialEq, Hash)]
 pub struct GreenNode {
-    pub(super) data: ThinArc<GreenNodeHead, PackedGreenElement>,
+    imp: sorbus::green::Node,
+}
+
+impl fmt::Debug for GreenNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("GreenNode")
+            .field("kind", &self.kind())
+            .field("text_len", &self.text_len())
+            .field("children", &self.children())
+            .finish()
+    }
 }
 
 impl GreenNode {
-    /// Creates new Node.
+    /// Creates a new node, without any caching.
     #[inline]
-    pub fn new<I>(kind: SyntaxKind, children: I) -> GreenNode
+    #[deprecated(note = "use the builder API to deduplicate nodes")]
+    pub fn new<I>(kind: SyntaxKind, children: I) -> Arc<GreenNode>
     where
         I: IntoIterator<Item = GreenElement>,
         I::IntoIter: ExactSizeIterator,
     {
-        let mut text_len: TextSize = 0.into();
-        let children = children
-            .into_iter()
-            .inspect(|it| text_len += it.text_len())
-            .map(PackedGreenElement::from);
-        let data = ThinArc::new(GreenNodeHead { kind, text_len: 0.into() }, children);
-
-        // XXX: fixup `text_len` after construction, because we can't iterate
-        // `children` twice.
-        let mut data: Arc<ThinData<GreenNodeHead, PackedGreenElement>> = data.into();
-        Arc::get_mut(&mut data).unwrap().head.text_len = text_len;
-
-        GreenNode { data: data.into() }
+        NodeCache::new().node(kind, children)
     }
 
-    /// Kind of this node.
+    /// The kind of this node.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.data.head.kind
+        SyntaxKind(self.imp.kind().0)
     }
 
-    /// Returns the length of the text covered by this node.
+    /// The length of the text covered by this node.
     #[inline]
     pub fn text_len(&self) -> TextSize {
-        self.data.head.text_len
+        self.imp.len()
     }
 
-    /// Children of this node.
+    /// The children of this node.
     #[inline]
     pub fn children(&self) -> Children<'_> {
-        Children { inner: self.data.slice.iter() }
-    }
-
-    pub(crate) fn ptr(&self) -> *const u8 {
-        let r: &ThinData<_, _> = &self.data;
-        r as *const _ as _
+        Children { imp: self.imp.children() }
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Children<'a> {
-    inner: slice::Iter<'a, PackedGreenElement>,
+    imp: sorbus::green::Children<'a>,
 }
 
-// NB: forward everything stable that iter::Slice specializes as of Rust 1.39.0
-impl ExactSizeIterator for Children<'_> {
-    #[inline(always)]
-    fn len(&self) -> usize {
-        self.inner.len()
+impl fmt::Debug for Children<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.clone()).finish()
+    }
+}
+
+// NB: forward everything that sorbus::green::Children specializes
+fn sorbus_child_to_rowan<'a>(
+    el: sorbus::NodeOrToken<
+        ArcBorrow<'a, sorbus::green::Node>,
+        ArcBorrow<'a, sorbus::green::Token>,
+    >,
+) -> GreenElementRef<'a> {
+    match el {
+        sorbus::NodeOrToken::Node(node) => unsafe {
+            // transmute from sorbus to rowan nominal type
+            NodeOrToken::Node(mem::transmute(node))
+        },
+        sorbus::NodeOrToken::Token(token) => unsafe {
+            // transmute from sorbus to rowan nominal type
+            NodeOrToken::Token(mem::transmute(token))
+        },
     }
 }
 
@@ -85,70 +89,55 @@ impl<'a> Iterator for Children<'a> {
     type Item = GreenElementRef<'a>;
 
     #[inline]
-    fn next(&mut self) -> Option<GreenElementRef<'a>> {
-        self.inner.next().map(PackedGreenElement::as_ref)
+    fn next(&mut self) -> Option<Self::Item> {
+        self.imp.next().map(sorbus_child_to_rowan)
     }
 
-    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        self.inner.size_hint()
+        self.imp.size_hint()
     }
 
-    #[inline]
-    fn count(self) -> usize
-    where
-        Self: Sized,
-    {
-        self.inner.count()
+    fn count(self) -> usize {
+        self.imp.count()
     }
 
-    #[inline]
-    fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        self.inner.nth(n).map(PackedGreenElement::as_ref)
-    }
-
-    #[inline]
-    fn last(mut self) -> Option<Self::Item>
-    where
-        Self: Sized,
-    {
+    fn last(mut self) -> Option<Self::Item> {
         self.next_back()
     }
 
-    #[inline]
-    fn fold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.imp.nth(n).map(sorbus_child_to_rowan)
+    }
+
+    fn fold<B, F>(self, init: B, mut f: F) -> B
     where
-        Fold: FnMut(Acc, Self::Item) -> Acc,
+        F: FnMut(B, Self::Item) -> B,
     {
-        let mut accum = init;
-        while let Some(x) = self.next() {
-            accum = f(accum, x);
-        }
-        accum
+        self.imp.fold(init, |acc, el| f(acc, sorbus_child_to_rowan(el)))
     }
 }
 
-impl<'a> DoubleEndedIterator for Children<'a> {
-    #[inline]
+impl ExactSizeIterator for Children<'_> {
+    #[inline(always)]
+    fn len(&self) -> usize {
+        self.imp.len()
+    }
+}
+
+impl DoubleEndedIterator for Children<'_> {
     fn next_back(&mut self) -> Option<Self::Item> {
-        self.inner.next_back().map(PackedGreenElement::as_ref)
+        self.imp.next_back().map(sorbus_child_to_rowan)
     }
 
-    #[inline]
     fn nth_back(&mut self, n: usize) -> Option<Self::Item> {
-        self.inner.nth_back(n).map(PackedGreenElement::as_ref)
+        self.imp.nth_back(n).map(sorbus_child_to_rowan)
     }
 
-    #[inline]
-    fn rfold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    fn rfold<B, F>(self, init: B, mut f: F) -> B
     where
-        Fold: FnMut(Acc, Self::Item) -> Acc,
+        F: FnMut(B, Self::Item) -> B,
     {
-        let mut accum = init;
-        while let Some(x) = self.next_back() {
-            accum = f(accum, x);
-        }
-        accum
+        self.imp.rfold(init, |acc, el| f(acc, sorbus_child_to_rowan(el)))
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,107 +1,53 @@
-use std::{convert::TryFrom, fmt, hash, mem::ManuallyDrop, ptr, sync::Arc};
-
-use crate::{green::SyntaxKind, SmolStr, TextSize};
-
-#[repr(align(2))] // NB: this is an at-least annotation
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct GreenTokenData {
-    kind: SyntaxKind,
-    text: SmolStr,
-}
+use {
+    crate::{
+        green::{NodeCache, SyntaxKind},
+        TextSize,
+    },
+    std::{
+        fmt,
+        sync::Arc,
+    },
+};
 
 /// Leaf node in the immutable tree.
+#[repr(transparent)]
+#[derive(Eq, PartialEq, Hash)]
 pub struct GreenToken {
-    ptr: ptr::NonNull<GreenTokenData>,
+    imp: sorbus::green::Token,
 }
 
-unsafe impl Send for GreenToken {} // where GreenTokenData: Send + Sync
-unsafe impl Sync for GreenToken {} // where GreenTokenData: Send + Sync
-
 impl GreenToken {
-    fn add_tag(ptr: ptr::NonNull<GreenTokenData>) -> ptr::NonNull<GreenTokenData> {
-        unsafe {
-            let ptr = ((ptr.as_ptr() as usize) | 1) as *mut GreenTokenData;
-            ptr::NonNull::new_unchecked(ptr)
-        }
-    }
-
-    fn remove_tag(ptr: ptr::NonNull<GreenTokenData>) -> ptr::NonNull<GreenTokenData> {
-        unsafe {
-            let ptr = ((ptr.as_ptr() as usize) & !1) as *mut GreenTokenData;
-            ptr::NonNull::new_unchecked(ptr)
-        }
-    }
-
-    fn data(&self) -> &GreenTokenData {
-        unsafe { &*Self::remove_tag(self.ptr).as_ptr() }
-    }
-
-    /// Creates new Token.
+    /// Creates a new token, without any caching.
     #[inline]
-    pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenToken {
-        let ptr = Arc::into_raw(Arc::new(GreenTokenData { kind, text }));
-        let ptr = ptr::NonNull::new(ptr as *mut _).unwrap();
-        GreenToken { ptr: Self::add_tag(ptr) }
+    #[deprecated(note = "use the builder API to deduplicate tokens")]
+    pub fn new(kind: SyntaxKind, text: &str) -> Arc<GreenToken> {
+        NodeCache::new().token(kind, text)
     }
 
-    /// Kind of this Token.
+    /// The kind of this token.
     #[inline]
     pub fn kind(&self) -> SyntaxKind {
-        self.data().kind
+        SyntaxKind(self.imp.kind().0)
     }
 
-    /// Text of this Token.
+    /// The text of this token.
     #[inline]
-    pub fn text(&self) -> &SmolStr {
-        &self.data().text
+    pub fn text(&self) -> &str {
+        self.imp.text()
     }
 
-    /// Returns the length of the text covered by this token.
+    /// The length of the text covered by this token.
     #[inline]
     pub fn text_len(&self) -> TextSize {
-        TextSize::try_from(self.text().len()).unwrap()
+        self.imp.len()
     }
 }
 
 impl fmt::Debug for GreenToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data = self.data();
-        f.debug_struct("GreenToken").field("kind", &data.kind).field("text", &data.text).finish()
-    }
-}
-
-impl Clone for GreenToken {
-    fn clone(&self) -> Self {
-        let ptr = Self::remove_tag(self.ptr);
-        let ptr = unsafe {
-            let arc = ManuallyDrop::new(Arc::from_raw(ptr.as_ptr()));
-            Arc::into_raw(Arc::clone(&arc))
-        };
-        let ptr = ptr::NonNull::new(ptr as *mut _).unwrap();
-        GreenToken { ptr: Self::add_tag(ptr) }
-    }
-}
-
-impl Eq for GreenToken {}
-impl PartialEq for GreenToken {
-    fn eq(&self, other: &Self) -> bool {
-        self.data() == other.data()
-    }
-}
-
-impl hash::Hash for GreenToken {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: hash::Hasher,
-    {
-        self.data().hash(state)
-    }
-}
-
-impl Drop for GreenToken {
-    fn drop(&mut self) {
-        unsafe {
-            Arc::from_raw(Self::remove_tag(self.ptr).as_ptr());
-        }
+        f.debug_struct("GreenToken")
+            .field("kind", &self.kind())
+            .field("text", &self.text())
+            .finish()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,26 +10,26 @@
 
 #[allow(unsafe_code)]
 mod green;
-#[allow(unsafe_code)]
-pub mod cursor;
+// #[allow(unsafe_code)]
+// pub mod cursor;
 
-pub mod api;
-mod syntax_text;
+// pub mod api;
+// mod syntax_text;
 mod utility_types;
-#[cfg(feature = "serde1")]
-mod serde_impls;
+// #[cfg(feature = "serde1")]
+// mod serde_impls;
 
 // Reexport types for working with strings. We might be too opinionated about
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
 // default.
-pub use smol_str::SmolStr;
-pub use text_size::{TextRange, TextSize, TextLen};
+pub use sorbus::ArcBorrow;
+pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
-    api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
-    },
-    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, SyntaxKind},
-    syntax_text::SyntaxText,
+    // api::{
+    //     Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+    // },
+    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, NodeCache, SyntaxKind},
+    // syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,17 +7,18 @@
     // missing_docs,
 )]
 #![deny(unsafe_code)]
+#![cfg_attr(miri, recursion_limit = "1024")] // recursive syntax tree drops
 
 #[allow(unsafe_code)]
 mod green;
-// #[allow(unsafe_code)]
-// pub mod cursor;
+#[allow(unsafe_code)]
+pub mod cursor;
 
-// pub mod api;
-// mod syntax_text;
+pub mod api;
+mod syntax_text;
 mod utility_types;
-// #[cfg(feature = "serde1")]
-// mod serde_impls;
+#[cfg(feature = "serde1")]
+mod serde_impls;
 
 // Reexport types for working with strings. We might be too opinionated about
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
@@ -26,10 +27,10 @@ pub use sorbus::ArcBorrow;
 pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
-    // api::{
-    //     Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
-    // },
+    api::{
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+    },
     green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, NodeCache, SyntaxKind},
-    // syntax_text::SyntaxText,
+    syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,10 +20,7 @@ mod utility_types;
 #[cfg(feature = "serde1")]
 mod serde_impls;
 
-// Reexport types for working with strings. We might be too opinionated about
-// these, as a custom interner might work better, but `SmolStr` is a pretty good
-// default.
-pub use sorbus::ArcBorrow;
+pub use rc_borrow::ArcBorrow;
 pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -44,7 +44,7 @@ impl<L: Language> Serialize for SyntaxToken<L> {
         let mut state = serializer.serialize_map(Some(3))?;
         state.serialize_entry("kind", &SerDisplay(DisplayDebug(self.kind())))?;
         state.serialize_entry("text_range", &self.text_range())?;
-        state.serialize_entry("text", &self.text().as_str())?;
+        state.serialize_entry("text", &self.text())?;
         state.end()
     }
 }

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -34,13 +34,6 @@ impl<N, T> NodeOrToken<N, T> {
             NodeOrToken::Token(token) => Some(token),
         }
     }
-
-    pub(crate) fn as_ref(&self) -> NodeOrToken<&N, &T> {
-        match self {
-            NodeOrToken::Node(node) => NodeOrToken::Node(node),
-            NodeOrToken::Token(token) => NodeOrToken::Token(token),
-        }
-    }
 }
 
 impl<N: ?Sized, T: ?Sized> NodeOrToken<Arc<N>, Arc<T>> {
@@ -52,11 +45,11 @@ impl<N: ?Sized, T: ?Sized> NodeOrToken<Arc<N>, Arc<T>> {
     }
 }
 
-impl<N: Clone, T: Clone> NodeOrToken<&N, &T> {
-    pub(crate) fn cloned(&self) -> NodeOrToken<N, T> {
+impl<N: ?Sized, T: ?Sized> NodeOrToken<ArcBorrow<'_, N>, ArcBorrow<'_, T>> {
+    pub(crate) fn to_owned(&self) -> NodeOrToken<Arc<N>, Arc<T>> {
         match *self {
-            NodeOrToken::Node(node) => NodeOrToken::Node(node.clone()),
-            NodeOrToken::Token(token) => NodeOrToken::Token(token.clone()),
+            NodeOrToken::Node(node) => NodeOrToken::Node(ArcBorrow::upgrade(node)),
+            NodeOrToken::Token(token) => NodeOrToken::Token(ArcBorrow::upgrade(token)),
         }
     }
 }

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,3 +1,5 @@
+use {std::sync::Arc, crate::ArcBorrow};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
     Node(N),
@@ -37,6 +39,15 @@ impl<N, T> NodeOrToken<N, T> {
         match self {
             NodeOrToken::Node(node) => NodeOrToken::Node(node),
             NodeOrToken::Token(token) => NodeOrToken::Token(token),
+        }
+    }
+}
+
+impl<N: ?Sized, T: ?Sized> NodeOrToken<Arc<N>, Arc<T>> {
+    pub(crate) fn borrowed(&self) -> NodeOrToken<ArcBorrow<'_, N>, ArcBorrow<'_, T>> {
+        match self {
+            NodeOrToken::Node(node) => NodeOrToken::Node(node.into()),
+            NodeOrToken::Token(token) => NodeOrToken::Token(token.into()),
         }
     }
 }


### PR DESCRIPTION
This rejigs rowan's green tree implementation to use sorbus's.

This implementation completely encapsulates sorbus. (That's part of the complexity of the patch, as we need to convert between `rowan::GreenNode` and `sorbus::green::Node` on the heap, copyless.) This is due in part to an initial attempt not doing this showing multiple impls rowan does that would be incoherent if it were to just reexport the sorbus types as appropriate.

rc-borrow, however, _is_ an added public dependency. This is because while rowan previously smashed the green node and token handles together by ensuring they never overlap, and then handed out effectively `&Arc<ActualNode>`, sorbus's node type is actually the type on the heap, and the owned handle is a normal `Arc<Node>`.

Basically, what was previously `GreenNode` is now `Arc<GreenNode>`, and what was previously `&GreenNode` is now `ArcBorrow<'_, GreenNode>`.

I verified that the tests and both examples run clean under miri (after increasing the recursion limit).

---

Draft until at the very least sorbus is published to crates.