### PR TITLE
Avoid allocating before we have checked if it is in the cache + don't rehash subtree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [dependencies]
 rustc-hash = "1.0.1"
 text-size = "1.0.0"
+smallvec = "1.4.0"
 smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
 thin-dst = "1.0.0"

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -72,11 +72,7 @@ impl NodeCache {
         // Future work: make hashing faster by avoiding rehashing of subtrees.
         if num_children <= MAX_CHILDREN {
             let mut hash = GreenNodeHash::new(kind);
-            let mut collected_children =
-                SmallVec::<[GreenElement; MAX_CHILDREN]>::with_capacity(MAX_CHILDREN);
-            for child in children {
-                collected_children.push(child);
-            }
+            let collected_children: SmallVec<[GreenElement; MAX_CHILDREN]> = children.collect();
             for child in collected_children.iter() {
                 hash.add_child(child);
             }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,5 +1,6 @@
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
+use super::token::GreenTokenData;
 use crate::{
     green::{GreenElement, GreenNode, GreenToken, SyntaxKind},
     NodeOrToken, SmolStr,
@@ -8,7 +9,7 @@ use crate::{
 #[derive(Default, Debug)]
 pub struct NodeCache {
     nodes: FxHashSet<GreenNode>,
-    tokens: FxHashSet<GreenToken>,
+    tokens: FxHashMap<GreenTokenData, GreenToken>,
 }
 
 impl NodeCache {
@@ -36,12 +37,16 @@ impl NodeCache {
     }
 
     fn token(&mut self, kind: SyntaxKind, text: SmolStr) -> GreenToken {
-        let mut token = GreenToken::new(kind, text);
-        match self.tokens.get(&token) {
-            Some(existing) => token = existing.clone(),
-            None => assert!(self.tokens.insert(token.clone())),
+        let token_data = GreenTokenData::new(kind, text.clone());
+
+        match self.tokens.get(&token_data) {
+            Some(existing) => existing.clone(),
+            None => {
+                let token = GreenToken::new(kind, text.clone());
+                self.tokens.insert(token_data, token.clone());
+                token
+            }
         }
-        token
     }
 }
 

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -58,8 +58,10 @@ impl Hash for GreenNodeHash {
 impl NodeCache {
     fn node<I>(&mut self, kind: SyntaxKind, children: I) -> GreenNode
     where
-        I: ExactSizeIterator<Item = GreenElement>,
+        I: IntoIterator<Item = GreenElement>,
+        I::IntoIter: ExactSizeIterator,
     {
+        let children = children.into_iter();
         let num_children = children.len();
         const MAX_CHILDREN: usize = 3;
         // Green nodes are fully immutable, so it's ok to deduplicate them.

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -10,7 +10,7 @@ pub(crate) struct GreenTokenData {
 }
 
 impl GreenTokenData {
-    pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenTokenData {
+    pub(crate) fn new(kind: SyntaxKind, text: SmolStr) -> GreenTokenData {
         GreenTokenData { kind, text }
     }
 }

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -4,9 +4,15 @@ use crate::{green::SyntaxKind, SmolStr, TextSize};
 
 #[repr(align(2))] // NB: this is an at-least annotation
 #[derive(Debug, PartialEq, Eq, Hash)]
-struct GreenTokenData {
+pub(crate) struct GreenTokenData {
     kind: SyntaxKind,
     text: SmolStr,
+}
+
+impl GreenTokenData {
+    pub fn new(kind: SyntaxKind, text: SmolStr) -> GreenTokenData {
+        GreenTokenData { kind, text }
+    }
 }
 
 /// Leaf node in the immutable tree.


### PR DESCRIPTION
We now check if the node/token is in the cache. If it is not in the cache, then we allocate. 
In addition, avoid hashing the complete sub-tree.

This speeds up analysis-stats on rust-analyser by ~5% on my local machine.

**Benchmark**
➜  rust-analyzer-base git:(master) hyperfine --warmup 1 --min-runs=3 '/home/simon/Documents/rust-analyzer/target/release/rust-analyzer analysis-stats .' '/home/simon/Documents/rust-analyzer-base/target/release/rust-analyzer analysis-stats .'
Benchmark #1: /home/simon/Documents/rust-analyzer/target/release/rust-analyzer analysis-stats .
  Time (mean ± σ):     46.027 s ±  0.419 s    [User: 45.120 s, System: 0.785 s]
  Range (min … max):   45.551 s … 46.343 s    3 runs
 
Benchmark #2: /home/simon/Documents/rust-analyzer-base/target/release/rust-analyzer analysis-stats .
  Time (mean ± σ):     48.445 s ±  0.457 s    [User: 47.657 s, System: 0.715 s]
  Range (min … max):   47.978 s … 48.892 s    3 runs
 
Summary
  '/home/simon/Documents/rust-analyzer/target/release/rust-analyzer analysis-stats .' ran
    1.05 ± 0.01 times faster than '/home/simon/Documents/rust-analyzer-base/target/release/rust-analyzer analysis-stats .'
