### PR TITLE
migrate from thin-dst to slice-dst and erasable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ description = "Library for generic lossless syntax trees"
 edition = "2018"
 
 [dependencies]
+erasable = "1.2.1"
 rustc-hash = "1.0.1"
-text-size = "1.0.0"
-smol_str = "0.1.10"
 serde = { version = "1.0.89", optional = true, default-features = false }
-thin-dst = "1.0.0"
+slice-dst = "1.4.1"
+smol_str = "0.1.10"
+text-size = "1.0.0"
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,6 +1,6 @@
 use std::{fmt, hash, mem};
 
-use thin_dst::ErasedPtr;
+use erasable::ErasedPtr;
 
 use crate::{
     green::{GreenNode, GreenToken, SyntaxKind},

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -10,6 +10,7 @@ struct GreenTokenData {
 }
 
 /// Leaf node in the immutable tree.
+#[repr(transparent)]
 pub struct GreenToken {
     ptr: ptr::NonNull<GreenTokenData>,
 }


### PR DESCRIPTION
thin-dst is deprecated in favor of using slice-dst and erasable, which provide a more principled and build-your-abstraction API.

This just ports the existing structure to use `erasable::Thin<Arc<slice_dst::SliceWithHeader<_, _>>>` instead of `thin_dst::ThinArc<_, _>`.