### PR TITLE
Add ability to gc node caches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 
 [dependencies]
 erasable = "1.2.1"
-rustc-hash = "1.0.1"
+hashbrown = "0.8.0"
 serde = { version = "1.0.89", optional = true, default-features = false }
 slice-dst = "1.4.1"
 smol_str = "0.1.10"

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -68,6 +68,10 @@ impl GreenNode {
         let r: &SliceWithHeader<_, _> = &*self.data;
         r as *const _ as _
     }
+
+    pub(super) fn strong_count(&self) -> usize {
+        Thin::with(&self.data, |node| Arc::strong_count(node))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -62,6 +62,12 @@ impl GreenToken {
     pub fn text_len(&self) -> TextSize {
         TextSize::try_from(self.text().len()).unwrap()
     }
+
+    pub(super) fn strong_count(&self) -> usize {
+        let ptr = Self::remove_tag(self.ptr);
+        let arc = unsafe { ManuallyDrop::new(Arc::from_raw(ptr.as_ptr())) };
+        Arc::strong_count(&arc)
+    }
 }
 
 impl fmt::Debug for GreenToken {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,13 +23,13 @@ mod serde_impls;
 // these, as a custom interner might work better, but `SmolStr` is a pretty good
 // default.
 pub use smol_str::SmolStr;
-pub use text_size::{TextRange, TextSize, TextLen};
+pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
         Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
     },
-    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, SyntaxKind},
+    green::{Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenToken, NodeCache, SyntaxKind},
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},
 };


### PR DESCRIPTION
Originally implemented in sorbus here: https://github.com/CAD97/sorbus/pull/46

Also exposes the `NodeCache` (closes #53) so that the gc is usable. While `GreenNodeBuilder` has had `with_cache` for a while, it's been impossible to _actually_ share the cache, as there was no way to get a cache to share!