### PR TITLE
Add cargo fmt to travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,11 @@ rust:
   - beta
 
 script:
+  - |
+    if [[ $TRAVIS_RUST_VERSION == "stable" ]]
+    then
+      rustup component add rustfmt
+      cargo fmt -- --check
+    fi
   - cargo test --all-features --all-targets
   - cargo test --release


### PR DESCRIPTION
## Note: To fix the cargo fmt build error the https://github.com/rust-analyzer/rowan/pull/64 PR needs to be merged first.