### PR TITLE
Fixed unsound Clone::clone() implementation of ThinArc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.12.4"
+version = "0.12.5"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -6,7 +6,7 @@ use std::{
     marker::PhantomData,
     mem::{self, ManuallyDrop},
     ops::Deref,
-    ptr, slice,
+    ptr,
     sync::atomic::{
         self,
         Ordering::{Acquire, Relaxed, Release},
@@ -259,7 +259,8 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     fn deref(&self) -> &Self::Target {
         unsafe {
             let len = self.length;
-            let fake_slice: *const [T] = slice::from_raw_parts(self as *const _ as *const T, len);
+            let fake_slice: *const [T] =
+                ptr::slice_from_raw_parts(self as *const _ as *const T, len);
             &*(fake_slice as *const HeaderSlice<H, [T]>)
         }
     }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -294,7 +294,7 @@ fn thin_to_thick<H, T>(
     thin: *mut ArcInner<HeaderSlice<H, [T; 0]>>,
 ) -> *mut ArcInner<HeaderSlice<H, [T]>> {
     let len = unsafe { (*thin).data.length };
-    let fake_slice: *mut [T] = unsafe { slice::from_raw_parts_mut(thin as *mut T, len) };
+    let fake_slice: *mut [T] = ptr::slice_from_raw_parts_mut(thin as *mut T, len);
     // Transplants metadata.
     fake_slice as *mut ArcInner<HeaderSlice<H, [T]>>
 }


### PR DESCRIPTION
In the custom ThinArc type in arc.rs the Clone implementation causes undefined behaviour. ThinArc is passed as an immutable reference, meaning no mutable references are allowed to be constructed from its data. (There is no UnsafeCell in sight).

In arc.rs line 297, a *mut T pointer obtained from the ThinArc contents is passed to slice::from_raw_parts_mut(), which casts the mutable pointer to a mutable reference internally, which is undefined behaviour.

https://github.com/rust-analyzer/rowan/blob/20c0564531763f4bac9e584670ae6e331a15eb21/src/arc.rs#L297

I replaced the call to ptr::slice_from_raw_parts_mut, which does not suffer from this problem. This also makes the wrapping unsafe {} block, and casting back to *mut [T] unnecessary.

Testing: Miri agrees