### PR TITLE
Borrow nodes of immutable syntax trees

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
-use std::{fmt, iter, marker::PhantomData, ops::Range};
+use std::{borrow::Cow, fmt, iter, marker::PhantomData, ops::Range};
 
 use crate::{
-    cursor, green::GreenTokenData, Direction, GreenNode, GreenToken, NodeOrToken, SyntaxKind,
-    SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
+    cursor, green::GreenTokenData, Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken,
+    SyntaxKind, SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
 };
 
 pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -121,7 +121,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.text()
     }
 
-    pub fn green(&self) -> GreenNode {
+    pub fn green(&self) -> Cow<'_, GreenNodeData> {
         self.raw.green()
     }
 

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::{
     green::{GreenNode, GreenToken, SyntaxKind},
     GreenNodeData, NodeOrToken, TextSize,
@@ -26,6 +28,13 @@ impl From<GreenToken> for GreenElement {
     #[inline]
     fn from(token: GreenToken) -> GreenElement {
         NodeOrToken::Token(token)
+    }
+}
+
+impl From<Cow<'_, GreenNodeData>> for GreenElement {
+    #[inline]
+    fn from(cow: Cow<'_, GreenNodeData>) -> Self {
+        NodeOrToken::Node(cow.into_owned())
     }
 }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::Borrow,
+    borrow::{Borrow, Cow},
     fmt,
     iter::{self, FusedIterator},
     mem::{self, ManuallyDrop},
@@ -68,6 +68,13 @@ impl Borrow<GreenNodeData> for GreenNode {
     #[inline]
     fn borrow(&self) -> &GreenNodeData {
         &*self
+    }
+}
+
+impl From<Cow<'_, GreenNodeData>> for GreenNode {
+    #[inline]
+    fn from(cow: Cow<'_, GreenNodeData>) -> Self {
+        cow.into_owned()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ pub use crate::{
         Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
     },
     green::{
-        Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken, SyntaxKind,
+        Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,
+        GreenTokenData, SyntaxKind,
     },
     syntax_text::SyntaxText,
     utility_types::{Direction, NodeOrToken, TokenAtOffset, WalkEvent},


### PR DESCRIPTION
Borrow green nodes of immutable syntax trees.
It requires some clarified invariants inside the `cursor` module. But overall, I think, it is safe for an API consumer.

(I couldn't find the latest 0.13.0-pre.3 version commit. Where should this go?)
