### PR TITLE
remove outdated comment

### DIFF
--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -9,11 +9,6 @@
 //! alongside this tutorial:
 //! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
 
-/// Currently, rowan doesn't have a hook to add your own interner,
-/// but `SmolStr` should be a "good enough" type for representing
-/// tokens.
-/// Additionally, rowan uses `TextSize` and `TextRange` types to
-/// represent utf8 offsets and ranges.
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]


### PR DESCRIPTION
This PR removes remaning documentation for `SmolStr`, which was already deleted in #90 ([here](https://github.com/rust-analyzer/rowan/pull/90/files#diff-dc731e6f71787c5e97c4656ce847c2695e3c866de2dce8be7e51709ae25595c2L17)).