### PR TITLE
Bump hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["xtask"]
 
 [dependencies]
 rustc-hash = "1.0.1"
-hashbrown = { version = "0.9", features = ["inline-more"], default-features = false }
+hashbrown = { version = "0.11.2", features = ["inline-more"], default-features = false }
 text-size = "1.1.0"
 memoffset = "0.6"
 countme = "2.0.0"


### PR DESCRIPTION
This should help compile times and allow us to use the newer version in rust-analyzer