### PR TITLE
Use some ptr::addr_of_mut for taking ptr addr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.13.0-pre.7"
+version = "0.13.0-pre.8"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -372,11 +372,11 @@ impl<H, T> ThinArc<H, T> {
             //
             // Note that any panics here (i.e. from the iterator) are safe, since
             // we'll just leak the uninitialized memory.
-            ptr::write(&mut ((*ptr).count), count);
-            ptr::write(&mut ((*ptr).data.header), header);
-            ptr::write(&mut ((*ptr).data.length), num_items);
+            ptr::write(ptr::addr_of_mut!((*ptr).count), count);
+            ptr::write(ptr::addr_of_mut!((*ptr).data.header), header);
+            ptr::write(ptr::addr_of_mut!((*ptr).data.length), num_items);
             if num_items != 0 {
-                let mut current = (*ptr).data.slice.as_mut_ptr();
+                let mut current = ptr::addr_of_mut!((*ptr).data.slice) as *mut T;
                 debug_assert_eq!(current as usize - buffer as usize, slice_offset);
                 for _ in 0..num_items {
                     ptr::write(


### PR DESCRIPTION
Relevant to #108, but I'm not certain if it addresses the miri failure or not. (Can't check because of https://github.com/rust-lang/miri/issues/705.)

Either way, this is a positive change, as previously we were creating `&mut` to uninitialized memory locations.