### PR TITLE
Fix memory leak in NodeData constructor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.13.1"
+version = "0.13.2"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -228,13 +228,11 @@ impl NodeData {
         green: Green,
         mutable: bool,
     ) -> ptr::NonNull<NodeData> {
+        let parent = ManuallyDrop::new(parent);
         let res = NodeData {
             _c: Count::new(),
             rc: Cell::new(1),
-            parent: {
-                let parent = ManuallyDrop::new(parent);
-                Cell::new(parent.as_ref().map(|it| it.ptr))
-            },
+            parent: Cell::new(parent.as_ref().map(|it| it.ptr)),
             index: Cell::new(index),
             green,
 
@@ -264,6 +262,7 @@ impl NodeData {
                     }
 
                     Box::from_raw(res);
+                    ManuallyDrop::into_inner(parent);
                     res = node as *mut _;
                     (*res).inc_rc();
                 }


### PR DESCRIPTION
Drop SyntaxNode in mutable trees when reusing a NodeData