### PR TITLE
Remove an unnecessary allocation/deallocation in NodeData::new

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -245,7 +245,8 @@ impl NodeData {
         unsafe {
             if mutable {
                 let res_ptr: *const NodeData = &res;
-                match sll::init((*res_ptr).parent().map(|it| &it.first), res_ptr.as_ref().unwrap()) {
+                match sll::init((*res_ptr).parent().map(|it| &it.first), res_ptr.as_ref().unwrap())
+                {
                     sll::AddToSllResult::AlreadyInSll(node) => {
                         if cfg!(debug_assertions) {
                             assert_eq!((*node).index(), (*res_ptr).index());
@@ -472,8 +473,10 @@ impl NodeData {
             }
 
             match sll::link(&self.first, child) {
-                sll::AddToSllResult::AlreadyInSll(_) => panic!("Child already in sorted linked list"),
-                it => it.add_to_sll(child)
+                sll::AddToSllResult::AlreadyInSll(_) => {
+                    panic!("Child already in sorted linked list")
+                }
+                it => it.add_to_sll(child),
             }
 
             match self.green() {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1278,5 +1278,4 @@ impl Iterator for PreorderWithTokens {
         next
     }
 }
-
 // endregion

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1279,37 +1279,4 @@ impl Iterator for PreorderWithTokens {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use crate::GreenNodeBuilder;
-    use super::*;
-
-    fn build_tree(chunks: &[&str]) -> GreenNode {
-        let mut builder = GreenNodeBuilder::new();
-        builder.start_node(SyntaxKind(62));
-        for &chunk in chunks.iter() {
-            builder.token(SyntaxKind(92), chunk.into())
-        }
-        builder.finish_node();
-        builder.finish()
-    }
-
-    #[test]
-    fn test_node_data_new() {
-        let green = build_tree(&["a"]);
-        let root = SyntaxNode::new_root_mut(green);
-
-        let green = build_tree(&["b"]);
-        let green = GreenNode::into_raw(green);
-        let green = Green::Node { ptr: Cell::new(green) };
-        NodeData::new(
-            Some(root),
-            0,
-            TextSize::from(3),
-            green,
-            true
-        );
-    }
-}
-
 // endregion

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -14,7 +14,7 @@ pub(crate) enum AddToSllResult<'a, E: Elem> {
     EmptyHead(&'a Cell<*const E>),
     SmallerThanHead(&'a Cell<*const E>),
     SmallerThanNotHead(*const E),
-    AlreadyInSll(*const E)
+    AlreadyInSll(*const E),
 }
 
 impl<'a, E: Elem> AddToSllResult<'a, E> {
@@ -44,14 +44,17 @@ impl<'a, E: Elem> AddToSllResult<'a, E> {
                     (*elem_ptr).prev().set(*curr);
                     (*elem_ptr).next().set(next);
                 }
-                AddToSllResult::NoHead | AddToSllResult::AlreadyInSll(_) => ()
+                AddToSllResult::NoHead | AddToSllResult::AlreadyInSll(_) => (),
             }
         }
     }
 }
 
 #[cold]
-pub(crate) fn init<'a, E: Elem>(head: Option<&'a Cell<*const E>>, elem: &E) -> AddToSllResult<'a, E> {
+pub(crate) fn init<'a, E: Elem>(
+    head: Option<&'a Cell<*const E>>,
+    elem: &E,
+) -> AddToSllResult<'a, E> {
     if let Some(head) = head {
         link(head, elem)
     } else {

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -3,21 +3,59 @@
 use std::{cell::Cell, cmp::Ordering, ptr};
 
 use crate::utility_types::Delta;
-
 pub(crate) unsafe trait Elem {
     fn prev(&self) -> &Cell<*const Self>;
     fn next(&self) -> &Cell<*const Self>;
     fn key(&self) -> &Cell<u32>;
 }
 
+pub(crate) enum AddToSllResult<'a, E: Elem> {
+    NoHead,
+    EmptyHead(&'a Cell<*const E>),
+    SmallerThanHead(&'a Cell<*const E>),
+    SmallerThanNotHead(*const E),
+    AlreadyInSll(*const E)
+}
+
+impl<'a, E: Elem> AddToSllResult<'a, E> {
+    pub(crate) fn add_to_sll(&self, elem_ptr: *const E) {
+        unsafe {
+            (*elem_ptr).prev().set(elem_ptr);
+            (*elem_ptr).next().set(elem_ptr);
+
+            match self {
+                // Case 1: empty head, replace it.
+                AddToSllResult::EmptyHead(head) => head.set(elem_ptr),
+
+                // Case 2: we are smaller than the head, replace it.
+                AddToSllResult::SmallerThanHead(head) => {
+                    let old_head = head.get();
+                    let prev = (*old_head).prev().replace(elem_ptr);
+                    (*prev).next().set(elem_ptr);
+                    (*elem_ptr).next().set(old_head);
+                    (*elem_ptr).prev().set(prev);
+                    head.set(elem_ptr);
+                }
+
+                // Case 3: insert in place found by looping
+                AddToSllResult::SmallerThanNotHead(curr) => {
+                    let next = (**curr).next().replace(elem_ptr);
+                    (*next).prev().set(elem_ptr);
+                    (*elem_ptr).prev().set(*curr);
+                    (*elem_ptr).next().set(next);
+                }
+                AddToSllResult::NoHead | AddToSllResult::AlreadyInSll(_) => ()
+            }
+        }
+    }
+}
+
 #[cold]
-pub(crate) fn init<E: Elem>(head: Option<&Cell<*const E>>, elem: &E) -> Result<(), *const E> {
-    elem.prev().set(elem);
-    elem.next().set(elem);
+pub(crate) fn init<'a, E: Elem>(head: Option<&'a Cell<*const E>>, elem: &E) -> AddToSllResult<'a, E> {
     if let Some(head) = head {
         link(head, elem)
     } else {
-        Ok(())
+        AddToSllResult::NoHead
     }
 }
 
@@ -42,25 +80,17 @@ pub(crate) fn unlink<E: Elem>(head: &Cell<*const E>, elem: &E) {
 }
 
 #[cold]
-pub(crate) fn link<E: Elem>(head: &Cell<*const E>, elem: &E) -> Result<(), *const E> {
-    let elem_ptr: *const E = elem;
-
+pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllResult<'a, E> {
     unsafe {
         let old_head = head.get();
         // Case 1: empty head, replace it.
         if old_head.is_null() {
-            head.set(elem_ptr);
-            return Ok(());
+            return AddToSllResult::EmptyHead(head);
         }
 
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {
-            let prev = (*old_head).prev().replace(elem_ptr);
-            (*prev).next().set(elem_ptr);
-            elem.next().set(old_head);
-            elem.prev().set(prev);
-            head.set(elem_ptr);
-            return Ok(());
+            return AddToSllResult::SmallerThanHead(head);
         }
 
         // Case 3: loop *backward* until we find insertion place. Because of
@@ -68,14 +98,8 @@ pub(crate) fn link<E: Elem>(head: &Cell<*const E>, elem: &E) -> Result<(), *cons
         let mut curr = (*old_head).prev().get();
         loop {
             match (*curr).key().cmp(elem.key()) {
-                Ordering::Less => {
-                    let next = (*curr).next().replace(elem_ptr);
-                    (*next).prev().set(elem_ptr);
-                    elem.prev().set(curr);
-                    elem.next().set(next);
-                    return Ok(());
-                }
-                Ordering::Equal => return Err(curr),
+                Ordering::Less => return AddToSllResult::SmallerThanNotHead(curr),
+                Ordering::Equal => return AddToSllResult::AlreadyInSll(curr),
                 Ordering::Greater => curr = (*curr).prev().get(),
             }
         }


### PR DESCRIPTION
`NodeData::new` unnecessarily allocates & deallocates when trying to create a `NodeData` that is already present in the SLL. This happens to be a fairly hot allocation/deallocation - when profiling rust-analyzer's `integrated_completion_benchmark` with DHAT, I saw that over 70% of its short-lived allocations were caused by this behaviour in `NodeData::new`. 

![Screen Shot 2021-09-26 at 4 31 05 PM](https://user-images.githubusercontent.com/28904678/134823195-ad020dba-11f0-4dd5-aa7a-8ff521788b18.png)

Removing this allocation/deallocation should speed up benchmarks that traverse the syntax tree. Here's some data I collected from rust-analyzer benchmarks:

<details>
  <summary>benchmark_parser before this change</summary>

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.46ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.78ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.17ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.70ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.43ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.76ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.66ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.75ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.02ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.74ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.08ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.80ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.07ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.76ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.68ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.78ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.33ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.74ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-4d9943f3b6397a4b --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.23ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.70ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s
</details>

Average tree traversal time: 3.751 ms

<details>
  <summary>benchmark_parser after this change</summary>
@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.46ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.60ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 30.46ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.70ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.92ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.65ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.79ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.54ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.65ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.65ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.42ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.58ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.74ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.61ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.26ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.55ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.74ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.55ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.03s

@ubuntu2004-002% RUN_SLOW_TESTS=1 RUN_SLOW_BENCHES=1 target/release/deps/syntax-fb903b75b1665314 --test --nocapture benchmark

running 1 test
Failed to create perf counter: Operation not permitted (os error 1)
parsing: 29.93ms
Failed to create perf counter: Operation not permitted (os error 1)
tree traversal: 3.63ms
test tests::benchmark_parser ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 54 filtered out; finished in 0.04s

</details>

Average tree traversal time: 3.606 ms (roughly a 3.9% decrease).

