### PR TITLE
Reduce the number of allocations needed to find a specific child/sibling

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -389,24 +389,30 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 }
 
 impl<L: Language> SyntaxNodeChildren<L> {
-    pub fn by_kind<F: Clone + Fn(SyntaxKind) -> bool>(
+    pub fn by_kind<'a>(
         self,
-        matcher: F,
-    ) -> SyntaxNodeChildrenByKind<F, L> {
+        matcher: &'a impl Fn(SyntaxKind) -> bool,
+    ) -> SyntaxNodeChildrenByKind<'a, L> {
         SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SyntaxNodeChildrenByKind<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
-    raw: cursor::SyntaxNodeChildrenByKind<F>,
+#[derive(Clone)]
+pub struct SyntaxNodeChildrenByKind<'a, L: Language> {
+    raw: cursor::SyntaxNodeChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
     _p: PhantomData<L>,
 }
 
-impl<F: Clone + Fn(SyntaxKind) -> bool, L: Language> Iterator for SyntaxNodeChildrenByKind<F, L> {
+impl<'a, L: Language> Iterator for SyntaxNodeChildrenByKind<'a, L> {
     type Item = SyntaxNode<L>;
     fn next(&mut self) -> Option<Self::Item> {
         self.raw.next().map(SyntaxNode::from)
+    }
+}
+
+impl<'a, L: Language> fmt::Debug for SyntaxNodeChildrenByKind<'a, L> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyntaxNodeChildrenByKind").finish()
     }
 }
 
@@ -424,26 +430,30 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
 }
 
 impl<L: Language> SyntaxElementChildren<L> {
-    pub fn by_kind<F: Clone + Fn(SyntaxKind) -> bool>(
+    pub fn by_kind<'a>(
         self,
-        matcher: F,
-    ) -> SyntaxElementChildrenByKind<F, L> {
+        matcher: &'a impl Fn(SyntaxKind) -> bool,
+    ) -> SyntaxElementChildrenByKind<'a, L> {
         SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct SyntaxElementChildrenByKind<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
-    raw: cursor::SyntaxElementChildrenByKind<F>,
+#[derive(Clone)]
+pub struct SyntaxElementChildrenByKind<'a, L: Language> {
+    raw: cursor::SyntaxElementChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
     _p: PhantomData<L>,
 }
 
-impl<F: Clone + Fn(SyntaxKind) -> bool, L: Language> Iterator
-    for SyntaxElementChildrenByKind<F, L>
-{
+impl<'a, L: Language> Iterator for SyntaxElementChildrenByKind<'a, L> {
     type Item = SyntaxElement<L>;
     fn next(&mut self) -> Option<Self::Item> {
         self.raw.next().map(NodeOrToken::from)
+    }
+}
+
+impl<'a, L: Language> fmt::Debug for SyntaxElementChildrenByKind<'a, L> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SyntaxElementChildrenByKind").finish()
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -391,7 +391,7 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 impl<L: Language> SyntaxNodeChildren<L> {
     pub fn by_kind<'a>(
         self,
-        matcher: &'a impl Fn(SyntaxKind) -> bool,
+        matcher: &'a dyn Fn(SyntaxKind) -> bool,
     ) -> SyntaxNodeChildrenByKind<'a, L> {
         SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }
@@ -432,7 +432,7 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
 impl<L: Language> SyntaxElementChildren<L> {
     pub fn by_kind<'a>(
         self,
-        matcher: &'a impl Fn(SyntaxKind) -> bool,
+        matcher: &'a dyn Fn(SyntaxKind) -> bool,
     ) -> SyntaxElementChildrenByKind<'a, L> {
         SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -392,18 +392,18 @@ impl<L: Language> SyntaxNodeChildren<L> {
     pub fn by_kind<F: Clone + Fn(SyntaxKind) -> bool>(
         self,
         matcher: F,
-    ) -> SyntaxNodeChildrenMatching<F, L> {
-        SyntaxNodeChildrenMatching { raw: self.raw.by_kind(matcher), _p: PhantomData }
+    ) -> SyntaxNodeChildrenByKind<F, L> {
+        SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxNodeChildrenMatching<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
-    raw: cursor::SyntaxNodeChildrenMatching<F>,
+pub struct SyntaxNodeChildrenByKind<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
+    raw: cursor::SyntaxNodeChildrenByKind<F>,
     _p: PhantomData<L>,
 }
 
-impl<F: Clone + Fn(SyntaxKind) -> bool, L: Language> Iterator for SyntaxNodeChildrenMatching<F, L> {
+impl<F: Clone + Fn(SyntaxKind) -> bool, L: Language> Iterator for SyntaxNodeChildrenByKind<F, L> {
     type Item = SyntaxNode<L>;
     fn next(&mut self) -> Option<Self::Item> {
         self.raw.next().map(SyntaxNode::from)
@@ -427,19 +427,19 @@ impl<L: Language> SyntaxElementChildren<L> {
     pub fn by_kind<F: Clone + Fn(SyntaxKind) -> bool>(
         self,
         matcher: F,
-    ) -> SyntaxElementChildrenMatching<F, L> {
-        SyntaxElementChildrenMatching { raw: self.raw.by_kind(matcher), _p: PhantomData }
+    ) -> SyntaxElementChildrenByKind<F, L> {
+        SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
     }
 }
 
 #[derive(Debug, Clone)]
-pub struct SyntaxElementChildrenMatching<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
-    raw: cursor::SyntaxElementChildrenMatching<F>,
+pub struct SyntaxElementChildrenByKind<F: Clone + Fn(SyntaxKind) -> bool, L: Language> {
+    raw: cursor::SyntaxElementChildrenByKind<F>,
     _p: PhantomData<L>,
 }
 
 impl<F: Clone + Fn(SyntaxKind) -> bool, L: Language> Iterator
-    for SyntaxElementChildrenMatching<F, L>
+    for SyntaxElementChildrenByKind<F, L>
 {
     type Item = SyntaxElement<L>;
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -137,7 +137,10 @@ impl<'a, L: Language> SyntaxNode<L> {
         SyntaxNodeChildren { raw: self.raw.children(), _p: PhantomData }
     }
 
-    pub fn children_matching(&self, matcher: fn(SyntaxKind) -> bool) -> SyntaxNodeChildrenMatching<L> {
+    pub fn children_matching(
+        &self,
+        matcher: fn(SyntaxKind) -> bool,
+    ) -> SyntaxNodeChildrenMatching<L> {
         SyntaxNodeChildrenMatching { raw: self.raw.children_matching(matcher), _p: PhantomData }
     }
 
@@ -145,8 +148,14 @@ impl<'a, L: Language> SyntaxNode<L> {
         SyntaxElementChildren { raw: self.raw.children_with_tokens(), _p: PhantomData }
     }
 
-    pub fn children_with_tokens_matching(&self, matcher: &'a impl Fn(SyntaxKind) -> bool) -> SyntaxElementChildrenMatching<'a, L> {
-        SyntaxElementChildrenMatching { raw: self.raw.children_with_tokens_matching(matcher), _p: PhantomData }
+    pub fn children_with_tokens_matching(
+        &self,
+        matcher: &'a impl Fn(SyntaxKind) -> bool,
+    ) -> SyntaxElementChildrenMatching<'a, L> {
+        SyntaxElementChildrenMatching {
+            raw: self.raw.children_with_tokens_matching(matcher),
+            _p: PhantomData,
+        }
     }
 
     pub fn first_child(&self) -> Option<SyntaxNode<L>> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -94,7 +94,7 @@ impl<L: Language> From<SyntaxToken<L>> for SyntaxElement<L> {
     }
 }
 
-impl<'a, L: Language> SyntaxNode<L> {
+impl<L: Language> SyntaxNode<L> {
     pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
@@ -148,7 +148,7 @@ impl<'a, L: Language> SyntaxNode<L> {
         SyntaxElementChildren { raw: self.raw.children_with_tokens(), _p: PhantomData }
     }
 
-    pub fn children_with_tokens_matching(
+    pub fn children_with_tokens_matching<'a>(
         &self,
         matcher: &'a impl Fn(SyntaxKind) -> bool,
     ) -> SyntaxElementChildrenMatching<'a, L> {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1245,7 +1245,7 @@ impl From<SyntaxToken> for SyntaxElement {
 pub struct SyntaxNodeChildren {
     parent: SyntaxNode,
     next: Option<SyntaxNode>,
-    next_initialized: bool
+    next_initialized: bool,
 }
 
 impl SyntaxNodeChildren {
@@ -1255,10 +1255,7 @@ impl SyntaxNodeChildren {
 
     pub fn by_kind<F: Fn(SyntaxKind) -> bool>(self, matcher: F) -> SyntaxNodeChildrenMatching<F> {
         if !self.next_initialized {
-            SyntaxNodeChildrenMatching {
-                next: self.parent.first_child_matching(&matcher),
-                matcher,
-            }
+            SyntaxNodeChildrenMatching { next: self.parent.first_child_matching(&matcher), matcher }
         } else {
             SyntaxNodeChildrenMatching {
                 next: self.next.and_then(|node| {
@@ -1308,7 +1305,7 @@ impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxNodeChildrenMatching<F> {
 pub struct SyntaxElementChildren {
     parent: SyntaxNode,
     next: Option<SyntaxElement>,
-    next_initialized: bool
+    next_initialized: bool,
 }
 
 impl SyntaxElementChildren {
@@ -1321,7 +1318,7 @@ impl SyntaxElementChildren {
         matcher: F,
     ) -> SyntaxElementChildrenMatching<F> {
         if !self.next_initialized {
-            SyntaxElementChildrenMatching  {
+            SyntaxElementChildrenMatching {
                 next: self.parent.first_child_or_token_matching(&matcher),
                 matcher,
             }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -436,7 +436,7 @@ impl NodeData {
         matcher: &impl Fn(SyntaxKind) -> bool,
     ) -> Option<SyntaxElement> {
         let mut siblings = self.green_siblings().enumerate();
-        let index = self.index() as usize + 1;
+        let index = self.index() as usize;
 
         siblings.nth(index);
         siblings.find_map(|(index, child)| {
@@ -685,25 +685,6 @@ impl SyntaxNode {
         })
     }
 
-    pub fn first_child_matching(
-        &self,
-        matcher: &impl Fn(SyntaxKind) -> bool,
-    ) -> Option<SyntaxNode> {
-        self.green_ref().children().raw.enumerate().find_map(|(index, child)| {
-            if !matcher(child.as_ref().kind()) {
-                return None;
-            }
-            child.as_ref().into_node().map(|green| {
-                SyntaxNode::new_child(
-                    green,
-                    self.clone(),
-                    index as u32,
-                    self.offset() + child.rel_offset(),
-                )
-            })
-        })
-    }
-
     pub fn last_child(&self) -> Option<SyntaxNode> {
         self.green_ref().children().raw.enumerate().rev().find_map(|(index, child)| {
             child.as_ref().into_node().map(|green| {
@@ -720,23 +701,6 @@ impl SyntaxNode {
     pub fn first_child_or_token(&self) -> Option<SyntaxElement> {
         self.green_ref().children().raw.next().map(|child| {
             SyntaxElement::new(child.as_ref(), self.clone(), 0, self.offset() + child.rel_offset())
-        })
-    }
-
-    pub fn first_child_or_token_matching(
-        &self,
-        matcher: &impl Fn(SyntaxKind) -> bool,
-    ) -> Option<SyntaxElement> {
-        self.green_ref().children().raw.find_map(|child| {
-            if !matcher(child.as_ref().kind()) {
-                return None;
-            }
-            Some(SyntaxElement::new(
-                child.as_ref(),
-                self.clone(),
-                0,
-                self.offset() + child.rel_offset(),
-            ))
         })
     }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -376,11 +376,10 @@ impl NodeData {
     }
 
     fn next_sibling(&self) -> Option<SyntaxNode> {
-        let mut siblings = self.green_siblings().enumerate();
+        let siblings = self.green_siblings().enumerate();
         let index = self.index() as usize;
 
-        siblings.nth(index);
-        siblings.find_map(|(index, child)| {
+        siblings.skip(index + 1).find_map(|(index, child)| {
             child.as_ref().into_node().and_then(|green| {
                 let parent = self.parent_node()?;
                 let offset = parent.offset() + child.rel_offset();
@@ -390,11 +389,10 @@ impl NodeData {
     }
 
     fn next_sibling_by_kind(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxNode> {
-        let mut siblings = self.green_siblings().enumerate();
+        let siblings = self.green_siblings().enumerate();
         let index = self.index() as usize;
 
-        siblings.nth(index);
-        siblings.find_map(|(index, child)| {
+        siblings.skip(index + 1).find_map(|(index, child)| {
             if !matcher(child.as_ref().kind()) {
                 return None;
             }
@@ -407,11 +405,10 @@ impl NodeData {
     }
 
     fn prev_sibling(&self) -> Option<SyntaxNode> {
-        let mut rev_siblings = self.green_siblings().enumerate().rev();
+        let rev_siblings = self.green_siblings().enumerate().rev();
         let index = rev_siblings.len() - (self.index() as usize);
 
-        rev_siblings.nth(index);
-        rev_siblings.find_map(|(index, child)| {
+        rev_siblings.skip(index + 1).find_map(|(index, child)| {
             child.as_ref().into_node().and_then(|green| {
                 let parent = self.parent_node()?;
                 let offset = parent.offset() + child.rel_offset();
@@ -435,11 +432,10 @@ impl NodeData {
         &self,
         matcher: &impl Fn(SyntaxKind) -> bool,
     ) -> Option<SyntaxElement> {
-        let mut siblings = self.green_siblings().enumerate();
+        let siblings = self.green_siblings().enumerate();
         let index = self.index() as usize;
 
-        siblings.nth(index);
-        siblings.find_map(|(index, child)| {
+        siblings.skip(index + 1).find_map(|(index, child)| {
             if !matcher(child.as_ref().kind()) {
                 return None;
             }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1253,11 +1253,11 @@ impl SyntaxNodeChildren {
         SyntaxNodeChildren { parent, next: None, next_initialized: false }
     }
 
-    pub fn by_kind<F: Fn(SyntaxKind) -> bool>(self, matcher: F) -> SyntaxNodeChildrenMatching<F> {
+    pub fn by_kind<F: Fn(SyntaxKind) -> bool>(self, matcher: F) -> SyntaxNodeChildrenByKind<F> {
         if !self.next_initialized {
-            SyntaxNodeChildrenMatching { next: self.parent.first_child_matching(&matcher), matcher }
+            SyntaxNodeChildrenByKind { next: self.parent.first_child_matching(&matcher), matcher }
         } else {
-            SyntaxNodeChildrenMatching {
+            SyntaxNodeChildrenByKind {
                 next: self.next.and_then(|node| {
                     if matcher(node.kind()) {
                         Some(node)
@@ -1286,12 +1286,12 @@ impl Iterator for SyntaxNodeChildren {
 }
 
 #[derive(Clone, Debug)]
-pub struct SyntaxNodeChildrenMatching<F: Fn(SyntaxKind) -> bool> {
+pub struct SyntaxNodeChildrenByKind<F: Fn(SyntaxKind) -> bool> {
     next: Option<SyntaxNode>,
     matcher: F,
 }
 
-impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxNodeChildrenMatching<F> {
+impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxNodeChildrenByKind<F> {
     type Item = SyntaxNode;
     fn next(&mut self) -> Option<SyntaxNode> {
         self.next.take().map(|next| {
@@ -1316,14 +1316,14 @@ impl SyntaxElementChildren {
     pub fn by_kind<F: Fn(SyntaxKind) -> bool>(
         self,
         matcher: F,
-    ) -> SyntaxElementChildrenMatching<F> {
+    ) -> SyntaxElementChildrenByKind<F> {
         if !self.next_initialized {
-            SyntaxElementChildrenMatching {
+            SyntaxElementChildrenByKind {
                 next: self.parent.first_child_or_token_matching(&matcher),
                 matcher,
             }
         } else {
-            SyntaxElementChildrenMatching {
+            SyntaxElementChildrenByKind {
                 next: self.next.and_then(|node| {
                     if matcher(node.kind()) {
                         Some(node)
@@ -1352,12 +1352,12 @@ impl Iterator for SyntaxElementChildren {
 }
 
 #[derive(Clone, Debug)]
-pub struct SyntaxElementChildrenMatching<F: Fn(SyntaxKind) -> bool> {
+pub struct SyntaxElementChildrenByKind<F: Fn(SyntaxKind) -> bool> {
     next: Option<SyntaxElement>,
     matcher: F,
 }
 
-impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxElementChildrenMatching<F> {
+impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxElementChildrenByKind<F> {
     type Item = SyntaxElement;
     fn next(&mut self) -> Option<SyntaxElement> {
         self.next.take().map(|next| {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1313,10 +1313,7 @@ impl SyntaxElementChildren {
         SyntaxElementChildren { parent, next: None, next_initialized: false }
     }
 
-    pub fn by_kind<F: Fn(SyntaxKind) -> bool>(
-        self,
-        matcher: F,
-    ) -> SyntaxElementChildrenByKind<F> {
+    pub fn by_kind<F: Fn(SyntaxKind) -> bool>(self, matcher: F) -> SyntaxElementChildrenByKind<F> {
         if !self.next_initialized {
             SyntaxElementChildrenByKind {
                 next: self.parent.first_child_or_token_matching(&matcher),

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -431,7 +431,10 @@ impl NodeData {
         })
     }
 
-    fn next_sibling_or_token_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxElement> {
+    fn next_sibling_or_token_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxElement> {
         let mut siblings = self.green_siblings().enumerate();
         let index = self.index() as usize + 1;
 
@@ -665,7 +668,10 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn children_matching<F: Fn(SyntaxKind) -> bool>(&self, matcher: F) -> SyntaxNodeChildrenMatching<F> {
+    pub fn children_matching<F: Fn(SyntaxKind) -> bool>(
+        &self,
+        matcher: F,
+    ) -> SyntaxNodeChildrenMatching<F> {
         SyntaxNodeChildrenMatching::new(self.clone(), matcher)
     }
 
@@ -675,7 +681,10 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn children_with_tokens_matching<F: Fn(SyntaxKind) -> bool>(&self, matcher: F) -> SyntaxElementChildrenMatching<F> {
+    pub fn children_with_tokens_matching<F: Fn(SyntaxKind) -> bool>(
+        &self,
+        matcher: F,
+    ) -> SyntaxElementChildrenMatching<F> {
         SyntaxElementChildrenMatching::new(self.clone(), matcher)
     }
 
@@ -692,7 +701,10 @@ impl SyntaxNode {
         })
     }
 
-    pub fn first_child_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxNode> {
+    pub fn first_child_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxNode> {
         self.green_ref().children().raw.enumerate().find_map(|(index, child)| {
             if !matcher(child.as_ref().kind()) {
                 return None;
@@ -727,12 +739,20 @@ impl SyntaxNode {
         })
     }
 
-    pub fn first_child_or_token_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxElement> {
+    pub fn first_child_or_token_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxElement> {
         self.green_ref().children().raw.find_map(|child| {
             if !matcher(child.as_ref().kind()) {
                 return None;
             }
-            Some(SyntaxElement::new(child.as_ref(), self.clone(), 0, self.offset() + child.rel_offset()))
+            Some(SyntaxElement::new(
+                child.as_ref(),
+                self.clone(),
+                0,
+                self.offset() + child.rel_offset(),
+            ))
         })
     }
 
@@ -751,7 +771,10 @@ impl SyntaxNode {
         self.data().next_sibling()
     }
 
-    pub fn next_sibling_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxNode> {
+    pub fn next_sibling_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxNode> {
         self.data().next_sibling_matching(matcher)
     }
 
@@ -763,7 +786,10 @@ impl SyntaxNode {
         self.data().next_sibling_or_token()
     }
 
-    pub fn next_sibling_or_token_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxElement> {
+    pub fn next_sibling_or_token_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxElement> {
         self.data().next_sibling_or_token_matching(matcher)
     }
 
@@ -992,7 +1018,10 @@ impl SyntaxToken {
         self.data().next_sibling_or_token()
     }
 
-    pub fn next_sibling_or_token_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxElement> {
+    pub fn next_sibling_or_token_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxElement> {
         self.data().next_sibling_or_token_matching(matcher)
     }
 
@@ -1115,7 +1144,10 @@ impl SyntaxElement {
         }
     }
 
-    pub fn next_sibling_or_token_matching(&self, matcher: &impl Fn(SyntaxKind) -> bool) -> Option<SyntaxElement> {
+    pub fn next_sibling_or_token_matching(
+        &self,
+        matcher: &impl Fn(SyntaxKind) -> bool,
+    ) -> Option<SyntaxElement> {
         match self {
             NodeOrToken::Node(it) => it.next_sibling_or_token_matching(matcher),
             NodeOrToken::Token(it) => it.next_sibling_or_token_matching(matcher),
@@ -1297,7 +1329,10 @@ pub struct SyntaxElementChildrenMatching<F: Fn(SyntaxKind) -> bool> {
 
 impl<F: Fn(SyntaxKind) -> bool> SyntaxElementChildrenMatching<F> {
     fn new(parent: SyntaxNode, matcher: F) -> SyntaxElementChildrenMatching<F> {
-        SyntaxElementChildrenMatching { next: parent.first_child_or_token_matching(&matcher), matcher }
+        SyntaxElementChildrenMatching {
+            next: parent.first_child_or_token_matching(&matcher),
+            matcher,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,8 +29,8 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,
-        SyntaxNodeChildrenByKind, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
+        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxNodeChildrenMatching, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxNodeChildrenMatching, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,
+        SyntaxNodeChildrenMatching, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 pub use crate::{
     api::{
         Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren,
-        SyntaxNodeChildrenMatching, SyntaxToken,
+        SyntaxNodeChildrenByKind, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,


### PR DESCRIPTION
A very common operation in rust-analyzer is finding a child/sibling of a `SyntaxNode` that matches a specific `SyntaxKind`. This is currently implemented by iterating through children and finding the first matching node. However, this causes unnecessary allocations - the children that don't match are allocated and quickly discarded. 

This PR aims to reduce these unnecessary allocations by providing methods to iterate through only the children/siblings that match the desired `SyntaxKind`. Children/siblings that don't match the desired `SyntaxKind` are not allocated in these iterators.

So, I've only implemented this optimization for iterating through children, but this optimization already seems quite promising. Below is the DHAT output from running rust-analyzer's integrated completion benchmarks.

DHAT output before this change (on the [master branch](https://github.com/theo-lw/rust-analyzer/tree/master) in my fork):

```
==196375== Total:     15,179,316,140 bytes in 107,064,174 blocks
==196375== At t-gmax: 587,308,085 bytes in 2,611,269 blocks
==196375== At t-end:  845,424 bytes in 1,480 blocks
==196375== Reads:     33,131,042,097 bytes
==196375== Writes:    17,949,507,478 bytes
```

DHAT output after this change (on this [branch](https://github.com/theo-lw/rust-analyzer/tree/optimize-child-iteration) where I used `children_matching` in `support::child`).

```
==82931== Total:     14,585,180,134 bytes in 97,752,267 blocks
==82931== At t-gmax: 585,555,693 bytes in 2,599,462 blocks
==82931== At t-end:  845,584 bytes in 1,483 blocks
==82931== Reads:     32,637,529,753 bytes
==82931== Writes:    17,171,029,456 bytes
```

This is roughly a 8.5% decrease in total blocks allocated and a 4% decrease in the total bytes allocated.
