### PR TITLE
[DRAFT] - Try to optimize preorder iteration with pool allocation

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -193,6 +193,10 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.descendants().map(SyntaxNode::from)
     }
 
+    pub fn descendants_pooled(&self, capacity: usize) -> impl Iterator<Item = SyntaxNode<L>> {
+        self.raw.descendants_pooled(capacity).map(SyntaxNode::from)
+    }
+
     pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> {
         self.raw.descendants_with_tokens().map(NodeOrToken::from)
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -207,6 +207,10 @@ impl<L: Language> SyntaxNode<L> {
         Preorder { raw: self.raw.preorder(), _p: PhantomData }
     }
 
+    pub fn preorder_pooled(&self, capacity: usize) -> Preorder<L> {
+        Preorder { raw: self.raw.preorder_pooled(capacity), _p: PhantomData }
+    }
+
     /// Traverse the subtree rooted at the current node (including the current
     /// node) in preorder, including tokens.
     pub fn preorder_with_tokens(&self) -> PreorderWithTokens<L> {

--- a/src/api.rs
+++ b/src/api.rs
@@ -193,10 +193,6 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.descendants().map(SyntaxNode::from)
     }
 
-    pub fn descendants_pooled(&self, capacity: usize) -> impl Iterator<Item = SyntaxNode<L>> {
-        self.raw.descendants_pooled(capacity).map(SyntaxNode::from)
-    }
-
     pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> {
         self.raw.descendants_with_tokens().map(NodeOrToken::from)
     }
@@ -205,10 +201,6 @@ impl<L: Language> SyntaxNode<L> {
     /// node) in preorder, excluding tokens.
     pub fn preorder(&self) -> Preorder<L> {
         Preorder { raw: self.raw.preorder(), _p: PhantomData }
-    }
-
-    pub fn preorder_pooled(&self, capacity: usize) -> Preorder<L> {
-        Preorder { raw: self.raw.preorder_pooled(capacity), _p: PhantomData }
     }
 
     /// Traverse the subtree rooted at the current node (including the current

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -244,7 +244,7 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
 pub(crate) struct HeaderSlice<H, T: ?Sized> {
     pub(crate) header: H,
     length: usize,
-    slice: T,
+    pub(crate) slice: T,
 }
 
 impl<H, T> HeaderSlice<H, [T]> {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -195,6 +195,7 @@ impl AllocatorStrategy {
 }
 
 impl Clone for AllocatorStrategy {
+    #[inline]
     fn clone(&self) -> Self {
         match self {
             AllocatorStrategy::Boxed => AllocatorStrategy::Boxed,
@@ -251,6 +252,7 @@ struct NodeDataDeallocator {
 }
 
 impl Drop for NodeDataDeallocator {
+    #[inline]
     fn drop(&mut self) {
         unsafe {
             self.data.as_ref().allocator_strategy.deallocate(self.data);

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -252,7 +252,6 @@ struct NodeDataDeallocator {
 }
 
 impl Drop for NodeDataDeallocator {
-    #[inline]
     fn drop(&mut self) {
         unsafe {
             self.data.as_ref().allocator_strategy.deallocate(self.data);

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -852,6 +852,11 @@ impl SyntaxNode {
     }
 
     #[inline]
+    pub fn preorder_pooled(&self, capacity: usize) -> Preorder {
+        self.preorder_in_allocator(AllocatorStrategy::new_pooled(capacity))
+    }
+
+    #[inline]
     fn preorder_in_allocator(&self, allocator_strategy: AllocatorStrategy) -> Preorder {
         Preorder::new(self.clone(), allocator_strategy)
     }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -259,8 +259,8 @@ unsafe fn free(mut data: ptr::NonNull<NodeData>) {
     loop {
         debug_assert_eq!(data.as_ref().rc.get(), 0);
         debug_assert!(data.as_ref().first.get().is_null());
+        let _to_drop = NodeDataDeallocator { data };
         let node = data.as_ref();
-        let _ = NodeDataDeallocator { data };
         match node.parent.take() {
             Some(parent) => {
                 debug_assert!(parent.as_ref().rc.get() > 0);

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -160,10 +160,12 @@ impl Default for AllocatorStrategy {
 }
 
 impl AllocatorStrategy {
+    #[inline]
     pub fn new_pooled(capacity: usize) -> Self {
         AllocatorStrategy::Pooled(Rc::new(RefCell::new(Pool::new_with_capacity(capacity))))
     }
 
+    #[inline]
     fn allocate(&self, val: NodeData) -> Result<ptr::NonNull<NodeData>, &'static str> {
         match self {
             AllocatorStrategy::Boxed => unsafe { Ok(ptr::NonNull::new_unchecked(Box::into_raw(Box::new(val)))) }
@@ -171,6 +173,7 @@ impl AllocatorStrategy {
         }
     }
 
+    #[inline]
     fn deallocate(&self, val: ptr::NonNull<NodeData>) {
         match self {
             AllocatorStrategy::Boxed => unsafe {
@@ -182,6 +185,7 @@ impl AllocatorStrategy {
         }
     }
 
+    #[inline]
     fn can_allocate(&self) -> bool {
         match self {
             AllocatorStrategy::Boxed => true,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -89,9 +89,10 @@ use std::{
     iter,
     marker::PhantomData,
     mem::{self, ManuallyDrop},
-    rc::Rc,
     ops::Range,
-    ptr, slice,
+    ptr,
+    rc::Rc,
+    slice,
 };
 
 use countme::Count;
@@ -189,8 +190,8 @@ impl Drop for SyntaxToken {
     }
 }
 
-struct NodeDataDeallocator { 
-    data: ptr::NonNull<NodeData>
+struct NodeDataDeallocator {
+    data: ptr::NonNull<NodeData>,
 }
 
 impl Drop for NodeDataDeallocator {
@@ -291,17 +292,13 @@ impl NodeData {
                         return ptr::NonNull::new_unchecked(res);
                     }
                     it => {
-                        let res = Self::POOL.with(move |pool| { 
-                            pool.borrow_mut().allocate(res)
-                        });
+                        let res = Self::POOL.with(move |pool| pool.borrow_mut().allocate(res));
                         it.add_to_sll(res.as_ptr());
                         return res;
                     }
                 }
             }
-            Self::POOL.with(move |pool| { 
-                pool.borrow_mut().allocate(res)
-            })
+            Self::POOL.with(move |pool| pool.borrow_mut().allocate(res))
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 mod green;
 
 #[allow(unsafe_code)]
-mod pool;
+pub mod pool;
 
 #[allow(unsafe_code)]
 pub mod cursor;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,10 @@
 
 #[allow(unsafe_code)]
 mod green;
+
+#[allow(unsafe_code)]
+mod pool;
+
 #[allow(unsafe_code)]
 pub mod cursor;
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -61,26 +61,31 @@ impl<T> Clone for PagePtr<T> {
 impl<T> Copy for PagePtr<T> {}
 
 impl<T> PagePtr<T> {
+    #[inline]
     fn next_page(&self) -> Option<Self> {
         unsafe { self.ptr.as_ref().header.next_page }
     }
 
+    #[inline]
     fn prev_page(&self) -> Option<Self> {
         unsafe { self.ptr.as_ref().header.prev_page }
     }
 
+    #[inline]
     fn set_next_page(&mut self, next: Option<Self>) {
         unsafe {
             self.ptr.as_mut().header.next_page = next;
         }
     }
 
+    #[inline]
     fn set_prev_page(&mut self, prev: Option<Self>) {
         unsafe {
             self.ptr.as_mut().header.prev_page = prev;
         }
     }
 
+    #[inline]
     fn link_next_page(&mut self, next: Option<Self>) {
         self.set_next_page(next);
         if let Some(mut ptr) = next {
@@ -88,6 +93,7 @@ impl<T> PagePtr<T> {
         }
     }
 
+    #[inline]
     fn link_prev_page(&mut self, prev: Option<Self>) {
         self.set_prev_page(prev);
         if let Some(mut ptr) = prev {
@@ -170,6 +176,7 @@ impl<T> PagePtr<T> {
         }
     }
 
+    #[inline]
     fn allocate(&mut self, item: T) -> ptr::NonNull<T> {
         let header = unsafe { &mut self.ptr.as_mut().header };
         unsafe {
@@ -197,7 +204,7 @@ pub struct Pool<T> {
 
 impl<T> Default for Pool<T> {
     fn default() -> Self {
-        Self::new(256, 4)
+        Self::new(1024, 4)
     }
 }
 
@@ -229,6 +236,7 @@ impl<T> Pool<T> {
         }
     }
 
+    #[inline]
     pub fn allocate(&mut self, item: T) -> ptr::NonNull<T> {
         if self.free_pages.is_none() {
             self.free_pages = Some(PagePtr::new(self.page_capacity, None, None));
@@ -252,6 +260,7 @@ impl<T> Pool<T> {
         result
     }
 
+    #[inline]
     pub fn deallocate(&mut self, mut item: ptr::NonNull<T>) {
         let mut chunk_ptr = ptr_to_chunk(item);
         let mut page = unsafe { chunk_ptr.as_ref().page };

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,132 @@
+use std::{ptr, mem::MaybeUninit, default::Default};
+
+pub struct Chunk<T> {
+    data: MaybeUninit<T>,
+    next: Option<ptr::NonNull<Chunk<T>>>,
+}
+
+impl<T> Default for Chunk<T> {
+    fn default() -> Self {
+        Self { data: MaybeUninit::uninit(), next: None }
+    }
+}
+
+impl<T> AsRef<T> for Chunk<T> {
+    fn as_ref(&self) -> &T {
+        unsafe { self.data.assume_init_ref() }
+    }
+}
+
+impl<T> AsMut<T> for Chunk<T> {
+    fn as_mut(&mut self) -> &mut T {
+        unsafe { self.data.assume_init_mut() }
+    }
+}
+
+pub struct Pool<T> {
+    data: Box<[Chunk<T>]>,
+    free_chunk: Option<ptr::NonNull<Chunk<T>>>,
+    capacity: usize,
+    num_chunks: usize,
+}
+
+impl<T> Default for Pool<T> {
+    fn default() -> Self {
+        Self::new_with_capacity(256)
+    }
+}
+
+impl<T> Pool<T> {
+    pub fn new_with_capacity(capacity: usize) -> Self {
+        debug_assert!(capacity > 0);
+        let mut vec = Vec::with_capacity(capacity);
+        for idx in 0..capacity {
+            vec.push(Chunk::default());
+            if idx > 0 {
+                unsafe {
+                    vec[idx - 1].next = Some(ptr::NonNull::new_unchecked(&mut vec[idx]));
+                }
+            }
+        }
+
+        Self {
+            free_chunk: unsafe { Some(ptr::NonNull::new_unchecked(&mut vec[0])) },
+            data: vec.into_boxed_slice(),
+            capacity,
+            num_chunks: 0,
+        }
+    }
+
+    pub fn allocate(&mut self, item: T) -> Result<ptr::NonNull<Chunk<T>>, &'static str> {
+        if !self.can_allocate() {
+            return Err("Pool is empty");
+        }
+
+        unsafe {
+            self.free_chunk.unwrap().as_mut().data.write(item);
+        }
+
+        self.num_chunks += 1;
+        let result = self.free_chunk.unwrap();
+
+        unsafe {
+            self.free_chunk = self.free_chunk.unwrap().as_ref().next;
+        }
+
+        Ok(result)
+    }
+
+    pub fn deallocate(&mut self, mut item: ptr::NonNull<Chunk<T>>) {
+        unsafe {
+            ptr::drop_in_place(item.as_mut().data.as_mut_ptr());
+            item.as_mut().next = self.free_chunk;
+        }
+        self.free_chunk = Some(item);
+        self.num_chunks -= 1;
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.num_chunks == 0
+    }
+
+    pub fn can_allocate(&self) -> bool {
+        self.num_chunks < self.capacity
+    }
+}
+
+mod tests {
+    use super::*;
+
+    struct TestStruct {
+        id: usize,
+    }
+
+    impl Drop for TestStruct {
+        fn drop(&mut self) {
+            println!("{} dropped", self.id);
+        }
+    }
+
+    #[test]
+    fn test_pool() {
+        let mut pool = Pool::default();
+        let mut allocated = Vec::new();
+        for id in 0..10 {
+            allocated.push(pool.allocate(TestStruct { id }).unwrap());
+        }
+
+        for id in 0..10 {
+            unsafe {
+                assert_eq!(allocated[id].as_ref().as_ref().id, id);
+            }
+        }
+
+        assert!(!pool.is_empty());
+
+        for it in allocated.iter() {
+            pool.deallocate(*it);
+        }
+
+        assert!(pool.is_empty());
+    }
+}

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,36 +1,18 @@
-use std::{ptr, mem::MaybeUninit, default::Default};
+use std::{alloc::{self, Layout}, ptr, mem::{self, MaybeUninit}, default::Default, marker::PhantomData};
+use crate::arc::HeaderSlice;
+
+use memoffset::offset_of;
 
 struct Chunk<T> {
     data: MaybeUninit<T>,
     next: Option<ptr::NonNull<Chunk<T>>>,
-}
-
-impl<T> Default for Chunk<T> {
-    fn default() -> Self {
-        Self { data: MaybeUninit::uninit(), next: None }
-    }
-}
-
-pub struct Pool<T> {
-    data: Box<[Chunk<T>]>,
-    free_chunk: Option<ptr::NonNull<Chunk<T>>>,
-    capacity: usize,
-    num_chunks: usize,
-}
-
-impl<T> Default for Pool<T> {
-    fn default() -> Self {
-        Self::new_with_capacity(256)
-    }
+    page: PagePtr<T>,
 }
 
 #[inline]
 fn ptr_to_chunk<T>(item: ptr::NonNull<T>) -> ptr::NonNull<Chunk<T>> {
-    let base = MaybeUninit::<Chunk<T>>::uninit();
-    let base_ptr = base.as_ptr();
+    let data_offset = offset_of!(Chunk<T>, data);
     unsafe {
-        let data_addr = ptr::addr_of!((*base_ptr).data);
-        let data_offset = (data_addr as usize) - (base_ptr as usize);
         ptr::NonNull::new_unchecked(((item.as_ptr() as usize) - data_offset) as *mut Chunk<T>)
     }
 }
@@ -42,60 +24,253 @@ fn chunk_to_ptr<T>(mut chunk: ptr::NonNull<Chunk<T>>) -> ptr::NonNull<T> {
     }
 }
 
-impl<T> Pool<T> {
-    pub fn new_with_capacity(capacity: usize) -> Self {
-        debug_assert!(capacity > 0);
-        let mut vec = Vec::with_capacity(capacity);
-        for idx in 0..capacity {
-            vec.push(Chunk::default());
-            if idx > 0 {
-                unsafe {
-                    vec[idx - 1].next = Some(ptr::NonNull::new_unchecked(&mut vec[idx]));
-                }
-            }
-        }
+impl<T> Default for Chunk<T> {
+    fn default() -> Self {
+        Self { data: MaybeUninit::uninit(), next: None, page: PagePtr { ptr: ptr::NonNull::dangling() } }
+    }
+}
 
-        Self {
-            free_chunk: unsafe { Some(ptr::NonNull::new_unchecked(&mut vec[0])) },
-            data: vec.into_boxed_slice(),
-            capacity,
-            num_chunks: 0,
+struct PageHeader<T> {
+    prev_page: Option<PagePtr<T>>,
+    next_page: Option<PagePtr<T>>,
+    free_chunk: Option<ptr::NonNull<Chunk<T>>>,
+    num_chunks: usize,
+    _p: PhantomData<T>,
+}
+
+type Page<T> = HeaderSlice<PageHeader<T>, [Chunk<T>; 0]>;
+
+struct PagePtr<T> {
+    ptr: ptr::NonNull<Page<T>>
+}
+
+impl<T> Clone for PagePtr<T> {
+    fn clone(&self) -> Self {
+        Self { ptr: self.ptr.clone() }
+    }
+}
+
+impl<T> Copy for PagePtr<T> {
+}
+
+impl<T> PagePtr<T> {
+    fn next_page(&self) -> Option<Self> {
+        unsafe { self.ptr.as_ref().header.next_page }
+    }
+
+    fn prev_page(&self) -> Option<Self> {
+        unsafe { self.ptr.as_ref().header.prev_page }
+    }
+
+    fn set_next_page(&mut self, next: Option<Self>) {
+        unsafe { self.ptr.as_mut().header.next_page = next; }
+    }
+
+    fn set_prev_page(&mut self, prev: Option<Self>) {
+        unsafe { self.ptr.as_mut().header.prev_page = prev; }
+    }
+
+    fn link_next_page(&mut self, next: Option<Self>) {
+        self.set_next_page(next);
+        if let Some(mut ptr) = next {
+            ptr.set_prev_page(Some(self.clone()));
         }
     }
 
-    pub fn allocate(&mut self, item: T) -> Result<ptr::NonNull<T>, &'static str> {
-        if !self.can_allocate() {
-            return Err("Pool is empty");
+    fn link_prev_page(&mut self, prev: Option<Self>) {
+        self.set_prev_page(prev);
+        if let Some(mut ptr) = prev {
+            ptr.set_next_page(Some(self.clone()));
         }
+    }
+
+    fn num_chunks(&self) -> usize {
+        unsafe { self.ptr.as_ref().header.num_chunks }
+    }
+
+    fn remove_from_list(&self) {
+        if let Some(mut prev) = self.prev_page() {
+            prev.set_next_page(self.next_page());
+        }
+
+        if let Some(mut next) = self.next_page() {
+            next.set_prev_page(self.prev_page());
+        }
+    }
+
+    fn free(&self) {
+        self.remove_from_list();
+        unsafe {
+            let _to_free = Box::from_raw(self.ptr.as_ptr());
+        }
+    }
+
+    fn new(capacity: usize, prev_page: Option<PagePtr<T>>, next_page: Option<PagePtr<T>>) -> Self { 
+        // Implementation mostly based on arc.rs
+        assert!(capacity > 0);
+
+        // Find size of the HeaderSlice
+        let slice_offset = offset_of!(Page<T>, slice);
+        let slice_size = mem::size_of::<Chunk<T>>().checked_mul(capacity).expect("size overflow");
+        let usable_size = slice_offset.checked_add(slice_size).expect("size overflows");
+
+        // Round size up to alignment
+        let align = mem::align_of::<Page<T>>();
+        let size = usable_size.wrapping_add(align - 1) & !(align -1);
+        assert!(size >= usable_size, "size overflows");
+
+        let layout = Layout::from_size_align(size, align).expect("invalid layout");
 
         unsafe {
-            self.free_chunk.unwrap().as_mut().data.write(item);
+            let buffer = alloc::alloc(layout);
+            if buffer.is_null() {
+                alloc::handle_alloc_error(layout);
+            }
+
+            let ptr = buffer as *mut Page<T>;
+            let result = Self { ptr: ptr::NonNull::new_unchecked(ptr) };
+
+            let mut current = ptr::addr_of_mut!((*ptr).slice) as *mut Chunk<T>;
+
+            let header = PageHeader {
+                prev_page,
+                next_page,
+                free_chunk: Some(ptr::NonNull::new_unchecked(current)),
+                num_chunks: 0,
+                _p: PhantomData,
+            };
+
+            ptr::write(ptr::addr_of_mut!((*ptr).header), header);
+            for idx in 0..capacity {
+                let chunk = Chunk {
+                    data: MaybeUninit::uninit(), 
+                    next: if idx == capacity - 1 {
+                        None
+                    } else {
+                        Some(ptr::NonNull::new_unchecked(current.offset(1)))
+                    },
+                    page: result,
+                };
+                ptr::write(current, chunk);
+                current = current.offset(1);
+            }
+
+            result
+        }
+    }
+
+    fn allocate(&mut self, item: T) -> ptr::NonNull<T> {
+        let header = unsafe { &mut self.ptr.as_mut().header };
+        unsafe {
+            header.free_chunk.unwrap().as_mut().data.write(item);
         }
 
-        self.num_chunks += 1;
-        let result = self.free_chunk.unwrap();
-        self.free_chunk = unsafe { self.free_chunk.unwrap().as_ref().next };
+        header.num_chunks += 1;
+        let result = header.free_chunk.unwrap();
+        header.free_chunk = unsafe { header.free_chunk.unwrap().as_ref().next };
 
-        Ok(chunk_to_ptr(result))
+        chunk_to_ptr(result)
+    }
+}
+
+pub struct Pool<T> {
+    free_pages: Option<PagePtr<T>>,
+    full_pages: Option<PagePtr<T>>,
+
+    num_empty_pages: usize,
+
+    max_empty_pages: usize,
+
+    page_capacity: usize,
+}
+
+impl<T> Default for Pool<T> {
+    fn default() -> Self {
+        Self::new(256, 4)
+    }
+}
+
+impl<T> Drop for Pool<T> {
+    fn drop(&mut self) {
+        while let Some(ptr) = self.free_pages {
+            self.free_pages = ptr.next_page();
+            ptr.free();
+        }
+
+        while let Some(ptr) = self.full_pages {
+            self.full_pages = ptr.next_page();
+            ptr.free();
+        }
+    }
+}
+
+impl<T> Pool<T> {
+    pub fn new(page_capacity: usize, max_empty_pages: usize) -> Self {
+        debug_assert!(page_capacity > 0);
+        debug_assert!(max_empty_pages > 0);
+
+        Self {
+            free_pages: None,
+            full_pages: None,
+            num_empty_pages: 0,
+            max_empty_pages,
+            page_capacity,
+        }
+    }
+
+    pub fn allocate(&mut self, item: T) -> ptr::NonNull<T> {
+        if self.free_pages.is_none() {
+            self.free_pages = Some(PagePtr::new(self.page_capacity, None, None));
+            self.num_empty_pages += 1;
+        }
+
+        let mut free_page = self.free_pages.unwrap();
+        if free_page.num_chunks() == 0 {
+            self.num_empty_pages -= 1;
+        }
+
+        let result = free_page.allocate(item);
+        if self.page_capacity == free_page.num_chunks() {
+            self.free_pages = free_page.next_page();
+            free_page.remove_from_list();
+            free_page.link_next_page(self.full_pages);
+            free_page.set_prev_page(None);
+            self.full_pages = Some(free_page);
+        }
+
+        result
     }
 
     pub fn deallocate(&mut self, mut item: ptr::NonNull<T>) {
         let mut chunk_ptr = ptr_to_chunk(item);
+        let mut page = unsafe { chunk_ptr.as_ref().page };
+        let was_full_page = unsafe { page.ptr.as_ref().header.num_chunks == self.page_capacity };
+        let empty_page = unsafe { page.ptr.as_ref().header.num_chunks - 1 == 0 };
 
         unsafe {
             ptr::drop_in_place(item.as_mut());
-            chunk_ptr.as_mut().next = self.free_chunk;
+            chunk_ptr.as_mut().next = page.ptr.as_ref().header.free_chunk;
+
+            page.ptr.as_mut().header.free_chunk = Some(chunk_ptr);
+            page.ptr.as_mut().header.num_chunks -= 1;
+
+            if was_full_page {
+                if page.prev_page().is_none() { // head of list
+                    self.full_pages = page.next_page();
+                }
+                page.remove_from_list();
+                page.link_next_page(self.free_pages);
+                page.set_prev_page(None);
+                self.free_pages = Some(page);
+            } else if empty_page && self.max_empty_pages <= self.num_empty_pages {
+                if page.prev_page().is_none() { // head of list
+                    self.free_pages = page.next_page();
+                }
+                page.free();
+            } else if empty_page {
+                self.num_empty_pages += 1;
+            }
         }
-        self.free_chunk = Some(chunk_ptr);
-        self.num_chunks -= 1;
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.num_chunks == 0
-    }
-
-    pub fn can_allocate(&self) -> bool {
-        self.num_chunks < self.capacity
     }
 }
 
@@ -114,25 +289,21 @@ mod tests {
 
     #[test]
     fn test_pool() {
-        let mut pool = Pool::default();
+        let mut pool = Pool::new(2, 10);
         let mut allocated = Vec::new();
-        for id in 0..10 {
-            allocated.push(pool.allocate(TestStruct { id }).unwrap());
+        for id in 0..100 {
+            allocated.push(pool.allocate(TestStruct { id }));
         }
 
-        for id in 0..10 {
+        for id in 0..100 {
             unsafe {
                 assert_eq!(allocated[id].as_ref().id, id);
             }
         }
 
-        assert!(!pool.is_empty());
-
         for it in allocated.iter() {
             pool.deallocate(*it);
         }
-
-        assert!(pool.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Preorder iteration allocates O(size of tree) nodes. However, there are some cases where only O(height of tree) nodes are alive at a given time. I'm trying to see if using a pool allocator can help avoid excess allocations in this case.

