### PR TITLE
Add AstPtr and AstNode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
-edition = "2018"
+edition = "2021"
 
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,8 +5,8 @@ use crate::{
     SyntaxKind, SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
 };
 
-pub trait Language: Sized + Clone + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
-    type Kind: fmt::Debug;
+pub trait Language: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
+    type Kind: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash;
 
     fn kind_from_raw(raw: SyntaxKind) -> Self::Kind;
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind;

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,0 +1,145 @@
+//! In rowan, syntax trees are transient objects.
+//!
+//! That means that we create trees when we need them, and tear them down to
+//! save memory. In this architecture, hanging on to a particular syntax node
+//! for a long time is ill-advisable, as that keeps the whole tree resident.
+//!
+//! Instead, we provide a [`SyntaxNodePtr`] type, which stores information about
+//! *location* of a particular syntax node in a tree. Its a small type which can
+//! be cheaply stored, and which can be resolved to a real [`SyntaxNode`] when
+//! necessary.
+
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    iter::successors,
+};
+
+use crate::{Language, SyntaxNode, TextRange};
+
+/// The main trait to go from untyped `SyntaxNode` to a typed ast. The
+/// conversion itself has zero runtime cost: ast and syntax nodes have exactly
+/// the same representation: a pointer to the tree root and a pointer to the
+/// node itself.
+pub trait AstNode {
+    type Language: Language;
+
+    fn can_cast(kind: <Self::Language as Language>::Kind) -> bool
+    where
+        Self: Sized;
+
+    fn cast(node: SyntaxNode<Self::Language>) -> Option<Self>
+    where
+        Self: Sized;
+
+    fn syntax(&self) -> &SyntaxNode<Self::Language>;
+
+    fn clone_for_update(&self) -> Self
+    where
+        Self: Sized,
+    {
+        Self::cast(self.syntax().clone_for_update()).unwrap()
+    }
+
+    fn clone_subtree(&self) -> Self
+    where
+        Self: Sized,
+    {
+        Self::cast(self.syntax().clone_subtree()).unwrap()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SyntaxNodePtr<L: Language> {
+    kind: L::Kind,
+    range: TextRange,
+}
+
+impl<L: Language> SyntaxNodePtr<L> {
+    pub fn new(node: &SyntaxNode<L>) -> Self {
+        Self { kind: node.kind(), range: node.text_range() }
+    }
+
+    /// "Dereference" the pointer to get the node it points to.
+    ///
+    /// Panics if node is not found, so make sure that `root` syntax tree is
+    /// equivalent (is build from the same text) to the tree which was
+    /// originally used to get this [`SyntaxNodePtr`].
+    ///
+    /// The complexity is linear in the depth of the tree and logarithmic in
+    /// tree width. As most trees are shallow, thinking about this as
+    /// `O(log(N))` in the size of the tree is not too wrong!
+    pub fn to_node(&self, root: &SyntaxNode<L>) -> SyntaxNode<L> {
+        assert!(root.parent().is_none());
+        successors(Some(root.clone()), |node| {
+            node.child_or_token_at_range(self.range).and_then(|it| it.into_node())
+        })
+        .find(|it| it.text_range() == self.range && it.kind() == self.kind)
+        .unwrap_or_else(|| panic!("can't resolve local ptr to SyntaxNode: {:?}", self))
+    }
+
+    pub fn cast<N: AstNode<Language = L>>(self) -> Option<AstPtr<N>> {
+        if !N::can_cast(self.kind) {
+            return None;
+        }
+        Some(AstPtr { raw: self })
+    }
+}
+
+/// Like `SyntaxNodePtr`, but remembers the type of node
+pub struct AstPtr<N: AstNode> {
+    raw: SyntaxNodePtr<N::Language>,
+}
+
+impl<N: AstNode> AstPtr<N> {
+    pub fn new(node: &N) -> Self {
+        Self { raw: SyntaxNodePtr::new(node.syntax()) }
+    }
+
+    pub fn to_node(&self, root: &SyntaxNode<N::Language>) -> N {
+        N::cast(self.raw.to_node(root)).unwrap()
+    }
+
+    pub fn syntax_node_ptr(&self) -> SyntaxNodePtr<N::Language> {
+        self.raw.clone()
+    }
+
+    pub fn cast<U: AstNode<Language = N::Language>>(self) -> Option<AstPtr<U>> {
+        if !U::can_cast(self.raw.kind) {
+            return None;
+        }
+        Some(AstPtr { raw: self.raw })
+    }
+}
+
+impl<N: AstNode> fmt::Debug for AstPtr<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AstPtr").field("raw", &self.raw).finish()
+    }
+}
+
+impl<N: AstNode> Clone for AstPtr<N> {
+    fn clone(&self) -> Self {
+        Self { raw: self.raw.clone() }
+    }
+}
+
+impl<N: AstNode> PartialEq for AstPtr<N> {
+    fn eq(&self, other: &AstPtr<N>) -> bool {
+        self.raw == other.raw
+    }
+}
+
+impl<N: AstNode> Eq for AstPtr<N> {}
+
+impl<N: AstNode> Hash for AstPtr<N> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.raw.hash(state)
+    }
+}
+
+impl<N: AstNode> From<AstPtr<N>> for SyntaxNodePtr<N::Language> {
+    fn from(ptr: AstPtr<N>) -> SyntaxNodePtr<N::Language> {
+        ptr.raw
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ mod sll;
 mod arc;
 #[cfg(feature = "serde1")]
 mod serde_impls;
+pub mod ast;
 
 pub use text_size::{TextLen, TextRange, TextSize};
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,7 +3,7 @@ name = "xtask"
 version = "0.0.0"
 publish = false
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 xaction = "0.2"


### PR DESCRIPTION
This basically lifts from 

- https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/syntax/src/ptr.rs
- https://github.com/rust-analyzer/rust-analyzer/blob/master/crates/syntax/src/ast.rs#L38-L64

I've found myself wanting `AstPtr` and `AstNode` in my own side projects and ended up basically copy-pasting them from rust-analyzer internals. Since these seem generic enough (not rust specific) maybe they could be here in rowan.

If this seems ok to merge I can follow up to migrate rust-analyzer to this.