### PR TITLE
Add kind() getter for SyntaxNodePtr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.1"
+version = "0.15.2"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -93,6 +93,11 @@ impl<L: Language> SyntaxNodePtr<L> {
         }
         Some(AstPtr { raw: self })
     }
+
+    /// Returns the kind of syntax node this points to.
+    pub fn kind(&self) -> L::Kind {
+        self.kind
+    }
 }
 
 /// Like [`SyntaxNodePtr`], but remembers the type of node.


### PR DESCRIPTION
This'll allow us to use `SyntaxNodePtr` in rowan without using rowan's `AstNode`, as talked about in https://github.com/rust-analyzer/rowan/pull/122#issuecomment-968278641

Also see https://github.com/rust-analyzer/rust-analyzer/pull/10692#issuecomment-986172314