### PR TITLE
Add ast support module, extracted from rust-analyzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.3"
+version = "0.15.4"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
I used this code from rust-analyzer in order to be able to build out my own AST structures. The only change I made was to make it generic over language. 