### PR TITLE
Rename `SyntaxToken::ancestors`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.4"
+version = "0.15.5"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -286,7 +286,14 @@ impl<L: Language> SyntaxToken<L> {
         self.raw.parent().map(SyntaxNode::from)
     }
 
+    /// Iterator over all the ancestors of this token excluding itself.
+    #[deprecated = "use `SyntaxToken::parent_ancestors` instead"]
     pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+        self.parent_ancestors()
+    }
+
+    /// Iterator over all the ancestors of this token excluding itself.
+    pub fn parent_ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 


### PR DESCRIPTION
bors r+
(does bors work again?)