### PR TITLE
Rename SyntaxNodePtr::range to SyntaxNodePtr::text_range

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.7"
+version = "0.15.8"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rowan
 
-[![Build Status](https://travis-ci.org/rust-analyzer/rowan.svg?branch=master)](https://travis-ci.org/rust-analyzer/rowan)
+[![Crates.io](https://img.shields.io/crates/v/rowan.svg)](https://crates.io/crates/rowan)
+[![Crates.io](https://img.shields.io/crates/d/rowan.svg)](https://crates.io/crates/rowan)
 
 Rowan is a library for lossless syntax trees, inspired in part by
 Swift's [libsyntax](https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax).

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -101,7 +101,7 @@ impl<L: Language> SyntaxNodePtr<L> {
     }
 
     /// Returns the range of the syntax node this points to.
-    pub fn range(&self) -> TextRange {
+    pub fn text_range(&self) -> TextRange {
         self.range
     }
 }


### PR DESCRIPTION
Didn't realize I copied the field name verbatim ... immediately yanked the previous version so this release should be fine