### PR TITLE
making use of logos instead of m_lexer in #examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ countme = "3.0.0"
 serde = { version = "1.0.89", optional = true, default-features = false }
 
 [dev-dependencies]
-m_lexer = "0.0.4"
+logos = "0.12.1"
 
 [features]
 serde1 = [ "serde", "text-size/serde" ]


### PR DESCRIPTION
because logos seems standard lexer in rust crates :) 

so this makes examples more approachable for newcomers and more production ready