### PR TITLE
Prevent use of SyntaxNodePtr and AstPtr on mutable trees

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -247,6 +247,10 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxNode::from(self.raw.clone_for_update())
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.raw.is_mutable()
+    }
+
     pub fn detach(&self) {
         self.raw.detach()
     }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -544,6 +544,10 @@ impl SyntaxNode {
         SyntaxNode { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.data().mutable
+    }
+
     pub fn clone_for_update(&self) -> SyntaxNode {
         assert!(!self.data().mutable);
         match self.parent() {


### PR DESCRIPTION
Both of these use source code locations to identify the node, which can get invalidated by syntax tree mutations. This commit adds assertions to prevent their use, and adds documentation to inform users of the issue

Fixes #150