### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.12"
+version = "0.15.13"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Now that #148 is in I'd like to have a new version so I can grab it.

It does look like CI is failing recently though. Maybe the token is expired? Or it needs to be the new format of crates.io tokens? https://blog.rust-lang.org/2023/06/23/improved-api-tokens-for-crates-io.html