### PR TITLE
Add rowan::api::SyntaxNode::new_root_mut()

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -98,6 +98,9 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
+    pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
+        SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
+    }
     /// Returns a green tree, equal to the green tree this node
     /// belongs two, except with this node substitute. The complexity
     /// of operation is proportional to the depth of the tree


### PR DESCRIPTION
Add rowan::api::SyntaxNode::new_root_mut()

This is a convenience method that allows creating a new mutable root node,
consistent with what exists on the cursor::SyntaxNode API.

Without this, I find myself using SyntaxNode::new_root(...).clone_for_update()
quite a lot.
