### PR TITLE
Fix pointer comparison warning on newer rustc

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -83,7 +83,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        std::ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {


### PR DESCRIPTION
```
arning: ambiguous wide pointer comparison, the comparison includes metadata which may not be expected
  --> src/arc.rs:86:9
   |
86 |         this.ptr() == other.ptr()
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(ambiguous_wide_pointer_comparisons)]` on by default
   ```
