### PR TITLE
Allow passing an iterable to `splice_children`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.16"
+version = "0.16.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -256,8 +256,12 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.detach()
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement<L>>) {
-        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from).collect::<Vec<_>>();
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement<L>>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
+        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from);
         self.raw.splice_children(to_delete, to_insert)
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -806,7 +806,11 @@ impl SyntaxNode {
         })
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement>) {
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
         assert!(self.data().mutable, "immutable tree: {}", self);
         for (i, child) in self.children_with_tokens().enumerate() {
             if to_delete.contains(&i) {


### PR DESCRIPTION
Should reduce two allocation when splicing children.