### PR TITLE
Implement Eq and Hash for GreenTokenData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.16"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
 edition = "2021"
-
+rust-version = "1.77.0"
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [workspace]
@@ -18,7 +18,6 @@ hashbrown = { version = "0.14.3", features = [
     "inline-more",
 ], default-features = false }
 text-size = "1.1.0"
-memoffset = "0.9"
 countme = "3.0.0"
 
 serde = { version = "1.0.89", optional = true, default-features = false }

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -111,7 +111,7 @@ impl<I: Iterator<Item = (SyntaxKind, String)>> Parser<I> {
 }
 
 fn print(indent: usize, element: SyntaxElement) {
-    let kind: SyntaxKind = element.kind().into();
+    let kind: SyntaxKind = element.kind();
     print!("{:indent$}", "", indent = indent);
     match element {
         NodeOrToken::Node(node) => {

--- a/src/api.rs
+++ b/src/api.rs
@@ -101,9 +101,10 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
     }
+
     /// Returns a green tree, equal to the green tree this node
-    /// belongs two, except with this node substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this node substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
         self.raw.replace_with(replacement)
     }
@@ -263,8 +264,8 @@ impl<L: Language> SyntaxNode<L> {
 
 impl<L: Language> SyntaxToken<L> {
     /// Returns a green tree, equal to the green tree this token
-    /// belongs two, except with this token substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this token substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
         self.raw.replace_with(new_token)
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -98,6 +98,9 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
+    pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
+        SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
+    }
     /// Returns a green tree, equal to the green tree this node
     /// belongs two, except with this node substitute. The complexity
     /// of operation is proportional to the depth of the tree

--- a/src/api.rs
+++ b/src/api.rs
@@ -247,6 +247,10 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxNode::from(self.raw.clone_for_update())
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.raw.is_mutable()
+    }
+
     pub fn detach(&self) {
         self.raw.detach()
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -214,7 +214,7 @@ impl<L: Language> SyntaxNode<L> {
     }
 
     /// Find a token in the subtree corresponding to this node, which covers the offset.
-    /// Precondition: offset must be withing node's range.
+    /// Precondition: offset must be within node's range.
     pub fn token_at_offset(&self, offset: TextSize) -> TokenAtOffset<SyntaxToken<L>> {
         self.raw.token_at_offset(offset).map(SyntaxToken::from)
     }
@@ -222,7 +222,7 @@ impl<L: Language> SyntaxNode<L> {
     /// Return the deepest node or token in the current subtree that fully
     /// contains the range. If the range is empty and is contained in two leaf
     /// nodes, either one can be returned. Precondition: range must be contained
-    /// withing the current node
+    /// within the current node
     pub fn covering_element(&self, range: TextRange) -> SyntaxElement<L> {
         NodeOrToken::from(self.raw.covering_element(range))
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -441,30 +441,11 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 }
 
 impl<L: Language> SyntaxNodeChildren<L> {
-    pub fn by_kind<'a>(
-        self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxNodeChildrenByKind<'a, L> {
-        SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxNodeChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxNodeChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxNodeChildrenByKind<'a, L> {
-    type Item = SyntaxNode<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(SyntaxNode::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxNodeChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxNodeChildrenByKind").finish()
+    pub fn by_kind(self, matcher: impl Fn(L::Kind) -> bool) -> impl Iterator<Item = SyntaxNode<L>> {
+        self.raw
+            .by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind)))
+            .into_iter()
+            .map(SyntaxNode::from)
     }
 }
 
@@ -482,30 +463,11 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
 }
 
 impl<L: Language> SyntaxElementChildren<L> {
-    pub fn by_kind<'a>(
+    pub fn by_kind(
         self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxElementChildrenByKind<'a, L> {
-        SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxElementChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxElementChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxElementChildrenByKind<'a, L> {
-    type Item = SyntaxElement<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(NodeOrToken::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxElementChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxElementChildrenByKind").finish()
+        matcher: impl Fn(L::Kind) -> bool,
+    ) -> impl Iterator<Item = SyntaxElement<L>> {
+        self.raw.by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind))).map(NodeOrToken::from)
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -83,7 +83,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        std::ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,12 +257,10 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
             let len = self.length;
             let fake_slice: *const [T] =
                 ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            &*(fake_slice as *const HeaderSlice<H, [T]>)
-        }
+            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, ManuallyDrop},
+    mem::{self, offset_of, ManuallyDrop},
     ops::Deref,
     ptr,
     sync::atomic::{
@@ -12,8 +12,6 @@ use std::{
         Ordering::{Acquire, Relaxed, Release},
     },
 };
-
-use memoffset::offset_of;
 
 /// A soft limit on the amount of references that may be made to an `Arc`.
 ///

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,10 +257,9 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-            let len = self.length;
-            let fake_slice: *const [T] =
-                ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
+        let len = self.length;
+        let fake_slice: *const [T] = ptr::slice_from_raw_parts(self as *const _ as *const T, len);
+        unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -544,6 +544,10 @@ impl SyntaxNode {
         SyntaxNode { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.data().mutable
+    }
+
     pub fn clone_for_update(&self) -> SyntaxNode {
         assert!(!self.data().mutable);
         match self.parent() {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -790,6 +790,7 @@ impl SyntaxNode {
                 Some(SyntaxNode { ptr })
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })
@@ -1234,6 +1235,7 @@ impl SyntaxElement {
                 }
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -478,7 +478,7 @@ impl NodeData {
 
         match self.green() {
             NodeOrToken::Node(green) => {
-                // Child is root, so it ownes the green node. Steal it!
+                // Child is root, so it owns the green node. Steal it!
                 let child_green = match &child.green {
                     Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.get()).into() },
                     Green::Token { ptr } => unsafe { GreenToken::from_raw(*ptr).into() },

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,11 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-        unsafe {
-            let green = GreenNode::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenNode::clone(&green)
-        }
     }
 }
 
@@ -194,8 +192,8 @@ impl ops::Deref for GreenNode {
 
     #[inline]
     fn deref(&self) -> &GreenNodeData {
+        let repr: &Repr = &self.ptr;
         unsafe {
-            let repr: &Repr = &self.ptr;
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenNodeData>(repr)
         }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,9 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenNode::clone(&green)
+        let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenNode::clone(&green)
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,9 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenToken::clone(&green)
+        let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenToken::clone(&green)
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,11 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-        unsafe {
-            let green = GreenToken::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenToken::clone(&green)
-        }
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,6 +1,7 @@
 use std::{
     borrow::Borrow,
     fmt,
+    hash::{Hash, Hasher},
     mem::{self, ManuallyDrop},
     ops, ptr,
 };
@@ -21,6 +22,7 @@ struct GreenTokenHead {
 
 type Repr = HeaderSlice<GreenTokenHead, [u8]>;
 type ReprThin = HeaderSlice<GreenTokenHead, [u8; 0]>;
+#[derive(Eq)]
 #[repr(transparent)]
 pub struct GreenTokenData {
     data: ReprThin,
@@ -29,6 +31,12 @@ pub struct GreenTokenData {
 impl PartialEq for GreenTokenData {
     fn eq(&self, other: &Self) -> bool {
         self.kind() == other.kind() && self.text() == other.text()
+    }
+}
+
+impl Hash for GreenTokenData {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        (*self.data).hash(state);
     }
 }
 
@@ -139,5 +147,20 @@ impl ops::Deref for GreenToken {
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenTokenData>(repr)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::{BuildHasher, RandomState};
+
+    use super::*;
+
+    #[test]
+    fn hash_borrow() {
+        let owned = GreenToken::new(SyntaxKind(42), "foobar");
+        let borrowed: &GreenTokenData = owned.borrow();
+        let s = RandomState::new();
+        assert_eq!(s.hash_one(&owned), s.hash_one(borrowed));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
-        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
+        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -90,7 +90,6 @@ pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllR
         return AddToSllResult::EmptyHead(head);
     }
     unsafe {
-
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {
             return AddToSllResult::SmallerThanHead(head);

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -84,12 +84,12 @@ pub(crate) fn unlink<E: Elem>(head: &Cell<*const E>, elem: &E) {
 
 #[cold]
 pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllResult<'a, E> {
+    let old_head = head.get();
+    // Case 1: empty head, replace it.
+    if old_head.is_null() {
+        return AddToSllResult::EmptyHead(head);
+    }
     unsafe {
-        let old_head = head.get();
-        // Case 1: empty head, replace it.
-        if old_head.is_null() {
-            return AddToSllResult::EmptyHead(head);
-        }
 
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {


### PR DESCRIPTION
`GreenToken` implements all traits required to use it as the key type of a hash map. It also implements `Borrow<GreenTokenData>`. Thus is would be nice if `GreenTokenData` also implemented `Eq` and `Hash` such that the result of `SyntaxToken::green` could be used for lookups in such a hash map without additional overhead in terms of syntax or runtime.