### PR TITLE
Fix prev_sibling indexing off-by-one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -408,7 +408,7 @@ impl NodeData {
         let rev_siblings = self.green_siblings().enumerate().rev();
         let index = rev_siblings.len().checked_sub(self.index() as usize)?;
 
-        rev_siblings.skip(index + 1).find_map(|(index, child)| {
+        rev_siblings.skip(index).find_map(|(index, child)| {
             child.as_ref().into_node().and_then(|green| {
                 let parent = self.parent_node()?;
                 let offset = parent.offset() + child.rel_offset();


### PR DESCRIPTION
The patch f06a2c903caa270e977a73ef5b9091f99e8fbe6c changed the code to use skip instead of nth, which lead to an off-by-one bug that was uncovered by unit tests in ludtwig, see [1].

[1]: https://github.com/MalteJanz/ludtwig/pull/122

Fixes: https://github.com/rust-analyzer/rowan/issues/175