### PR TITLE
move size assert from const to tests

### DIFF
--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -12,7 +12,6 @@ use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::{GreenElement, GreenElementRef, SyntaxKind},
-    utility_types::static_assert,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,8 +27,6 @@ pub(crate) enum GreenChild {
     Node { rel_offset: TextSize, node: GreenNode },
     Token { rel_offset: TextSize, token: GreenToken },
 }
-#[cfg(target_pointer_width = "64")]
-static_assert!(mem::size_of::<GreenChild>() == mem::size_of::<usize>() * 2);
 
 type Repr = HeaderSlice<GreenNodeHead, [GreenChild]>;
 type ReprThin = HeaderSlice<GreenNodeHead, [GreenChild; 0]>;
@@ -356,3 +353,16 @@ impl DoubleEndedIterator for Children<'_> {
 }
 
 impl FusedIterator for Children<'_> {}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn check_green_child_size() {
+        use super::GreenChild;
+        use std::mem;
+
+        assert_eq!(mem::size_of::<GreenChild>(), mem::size_of::<usize>() * 2);
+    }
+}

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -149,14 +149,6 @@ impl<T> Iterator for TokenAtOffset<T> {
 
 impl<T> ExactSizeIterator for TokenAtOffset<T> {}
 
-macro_rules! _static_assert {
-    ($expr:expr) => {
-        const _: i32 = 0 / $expr as i32;
-    };
-}
-
-pub(crate) use _static_assert as static_assert;
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum Delta<T> {
     Add(T),


### PR DESCRIPTION
Struct layouts aren't guaranteed and -Zrandomize-layout exercises this right. To compile the whole rust-lang/rust repo with layout randomization we can't have static asserts like these.

Fixes #168