### PR TITLE
Slap `derive(Debug, Clone)` on preorder iterators

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -472,6 +472,7 @@ impl<L: Language> SyntaxElementChildren<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder<L: Language> {
     raw: cursor::Preorder,
     _p: PhantomData<L>,
@@ -490,6 +491,7 @@ impl<L: Language> Iterator for Preorder<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens<L: Language> {
     raw: cursor::PreorderWithTokens,
     _p: PhantomData<L>,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1474,6 +1474,7 @@ impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxElementChildrenByKind<F> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder {
     start: SyntaxNode,
     next: Option<WalkEvent<SyntaxNode>>,
@@ -1529,6 +1530,7 @@ impl Iterator for Preorder {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens {
     start: SyntaxElement,
     next: Option<WalkEvent<SyntaxElement>>,


### PR DESCRIPTION
I need them cloneable.