### PR TITLE
feat: make no-std compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.16"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.16"
+version = "0.16.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,23 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
-edition = "2021"
-rust-version = "1.77.0"
+edition = "2024"
+rust-version = "1.85.0"
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [workspace]
 members = ["xtask"]
 
 [dependencies]
-rustc-hash = "1.0.1"
-hashbrown = { version = "0.14.3", features = [
-    "inline-more",
+rustc-hash = "2.1.1"
+hashbrown = { version = "0.15.2", features = [
+	"inline-more",
+	"raw-entry",
 ], default-features = false }
-text-size = "1.1.0"
-countme = "3.0.0"
+text-size = "1.1.1"
+countme = "3.0.1"
 
-serde = { version = "1.0.89", optional = true, default-features = false }
+serde = { version = "1.0.218", optional = true, default-features = false }
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
 edition = "2021"
-
+rust-version = "1.77.0"
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [workspace]
@@ -18,7 +18,6 @@ hashbrown = { version = "0.14.3", features = [
     "inline-more",
 ], default-features = false }
 text-size = "1.1.0"
-memoffset = "0.9"
 countme = "3.0.0"
 
 serde = { version = "1.0.89", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,11 @@ exclude = [".github/", "bors.toml", "rustfmt.toml"]
 members = ["xtask"]
 
 [dependencies]
-rustc-hash = "2.1.1"
+rustc-hash = { version = "2.1.1", default-features = false }
 hashbrown = { version = "0.15.2", features = [
 	"inline-more",
 	"raw-entry",
 ], default-features = false }
-text-size = "1.1.1"
-countme = "3.0.1"
 
 serde = { version = "1.0.218", optional = true, default-features = false }
 
@@ -27,4 +25,5 @@ serde = { version = "1.0.218", optional = true, default-features = false }
 m_lexer = "0.0.4"
 
 [features]
-serde1 = ["serde", "text-size/serde"]
+std = ["rustc-hash/std"]
+serde1 = ["dep:serde"]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rowan
 
+[![docs.rs](https://docs.rs/rowan/badge.svg)](https://docs.rs/rowan/)
 [![Crates.io](https://img.shields.io/crates/v/rowan.svg)](https://crates.io/crates/rowan)
 [![Crates.io](https://img.shields.io/crates/d/rowan.svg)](https://crates.io/crates/rowan)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Rowan is a library for lossless syntax trees, inspired in part by
 Swift's [libsyntax](https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax).
 
-A conceptual overview is available in the [rust-analyzer repo](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md).
+A conceptual overview is available in the [rust-analyzer book](https://rust-analyzer.github.io/book/contributing/syntax.html).
 
 See `examples/s_expressions` for a tutorial, and [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/) for real-world usage.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Rowan is a library for lossless syntax trees, inspired in part by
 Swift's [libsyntax](https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax).
 
-A conceptual overview is available in the [rust-analyzer book](https://rust-analyzer.github.io/book/contributing/syntax.html).
+A conceptual overview is available in the [rust-analyzer repo](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md).
 
 See `examples/s_expressions` for a tutorial, and [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/) for real-world usage.
 

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -111,7 +111,7 @@ impl<I: Iterator<Item = (SyntaxKind, String)>> Parser<I> {
 }
 
 fn print(indent: usize, element: SyntaxElement) {
-    let kind: SyntaxKind = element.kind().into();
+    let kind: SyntaxKind = element.kind();
     print!("{:indent$}", "", indent = indent);
     match element {
         NodeOrToken::Node(node) => {

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -32,6 +32,7 @@ enum SyntaxKind {
     OPERATION,
     ROOT,
 }
+
 use SyntaxKind::*;
 
 impl From<SyntaxKind> for rowan::SyntaxKind {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -7,7 +7,7 @@
 //!
 //! It's suggested to read the conceptual overview of the design
 //! alongside this tutorial:
-//! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
+//! https://rust-analyzer.github.io/book/contributing/syntax.html
 
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -7,7 +7,7 @@
 //!
 //! It's suggested to read the conceptual overview of the design
 //! alongside this tutorial:
-//! https://rust-analyzer.github.io/book/contributing/syntax.html
+//! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
 
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.
@@ -194,8 +194,10 @@ fn parse(text: &str) -> Parse {
 /// has identity semantics.
 
 type SyntaxNode = rowan::SyntaxNode<Lang>;
+
 #[allow(unused)]
 type SyntaxToken = rowan::SyntaxToken<Lang>;
+
 #[allow(unused)]
 type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 
@@ -255,11 +257,7 @@ macro_rules! ast_node {
         impl $ast {
             #[allow(unused)]
             fn cast(node: SyntaxNode) -> Option<Self> {
-                if node.kind() == $kind {
-                    Some(Self(node))
-                } else {
-                    None
-                }
+                if node.kind() == $kind { Some(Self(node)) } else { None }
             }
         }
     };

--- a/src/api.rs
+++ b/src/api.rs
@@ -101,9 +101,10 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
     }
+
     /// Returns a green tree, equal to the green tree this node
-    /// belongs two, except with this node substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this node substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
         self.raw.replace_with(replacement)
     }
@@ -263,8 +264,8 @@ impl<L: Language> SyntaxNode<L> {
 
 impl<L: Language> SyntaxToken<L> {
     /// Returns a green tree, equal to the green tree this token
-    /// belongs two, except with this token substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this token substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
         self.raw.replace_with(new_token)
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -98,6 +98,9 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
+    pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
+        SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
+    }
     /// Returns a green tree, equal to the green tree this node
     /// belongs two, except with this node substitute. The complexity
     /// of operation is proportional to the depth of the tree

--- a/src/api.rs
+++ b/src/api.rs
@@ -247,6 +247,10 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxNode::from(self.raw.clone_for_update())
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.raw.is_mutable()
+    }
+
     pub fn detach(&self) {
         self.raw.detach()
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, fmt, iter, marker::PhantomData, ops::Range};
 
 use crate::{
-    cursor, green::GreenTokenData, Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken,
-    SyntaxKind, SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
+    Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken, SyntaxKind, SyntaxText,
+    TextRange, TextSize, TokenAtOffset, WalkEvent, cursor, green::GreenTokenData,
 };
 
 pub trait Language: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -446,10 +446,7 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 
 impl<L: Language> SyntaxNodeChildren<L> {
     pub fn by_kind(self, matcher: impl Fn(L::Kind) -> bool) -> impl Iterator<Item = SyntaxNode<L>> {
-        self.raw
-            .by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind)))
-            .into_iter()
-            .map(SyntaxNode::from)
+        self.raw.by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind))).map(SyntaxNode::from)
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -472,6 +472,7 @@ impl<L: Language> SyntaxElementChildren<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder<L: Language> {
     raw: cursor::Preorder,
     _p: PhantomData<L>,
@@ -490,6 +491,7 @@ impl<L: Language> Iterator for Preorder<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens<L: Language> {
     raw: cursor::PreorderWithTokens,
     _p: PhantomData<L>,

--- a/src/api.rs
+++ b/src/api.rs
@@ -133,7 +133,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.parent().map(Self::from)
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -219,7 +219,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.last_token().map(SyntaxToken::from)
     }
 
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.siblings(direction).map(SyntaxNode::from)
     }
 
@@ -230,11 +230,11 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.siblings_with_tokens(direction).map(SyntaxElement::from)
     }
 
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.descendants().map(SyntaxNode::from)
     }
 
-    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> {
+    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw.descendants_with_tokens().map(NodeOrToken::from)
     }
 
@@ -337,12 +337,12 @@ impl<L: Language> SyntaxToken<L> {
 
     /// Iterator over all the ancestors of this token excluding itself.
     #[deprecated = "use `SyntaxToken::parent_ancestors` instead"]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.parent_ancestors()
     }
 
     /// Iterator over all the ancestors of this token excluding itself.
-    pub fn parent_ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn parent_ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -356,7 +356,7 @@ impl<L: Language> SyntaxToken<L> {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement<L>> {
+    ) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw.siblings_with_tokens(direction).map(SyntaxElement::from)
     }
 
@@ -403,7 +403,7 @@ impl<L: Language> SyntaxElement<L> {
         }
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -214,7 +214,7 @@ impl<L: Language> SyntaxNode<L> {
     }
 
     /// Find a token in the subtree corresponding to this node, which covers the offset.
-    /// Precondition: offset must be withing node's range.
+    /// Precondition: offset must be within node's range.
     pub fn token_at_offset(&self, offset: TextSize) -> TokenAtOffset<SyntaxToken<L>> {
         self.raw.token_at_offset(offset).map(SyntaxToken::from)
     }
@@ -222,7 +222,7 @@ impl<L: Language> SyntaxNode<L> {
     /// Return the deepest node or token in the current subtree that fully
     /// contains the range. If the range is empty and is contained in two leaf
     /// nodes, either one can be returned. Precondition: range must be contained
-    /// withing the current node
+    /// within the current node
     pub fn covering_element(&self, range: TextRange) -> SyntaxElement<L> {
         NodeOrToken::from(self.raw.covering_element(range))
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -441,30 +441,11 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 }
 
 impl<L: Language> SyntaxNodeChildren<L> {
-    pub fn by_kind<'a>(
-        self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxNodeChildrenByKind<'a, L> {
-        SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxNodeChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxNodeChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxNodeChildrenByKind<'a, L> {
-    type Item = SyntaxNode<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(SyntaxNode::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxNodeChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxNodeChildrenByKind").finish()
+    pub fn by_kind(self, matcher: impl Fn(L::Kind) -> bool) -> impl Iterator<Item = SyntaxNode<L>> {
+        self.raw
+            .by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind)))
+            .into_iter()
+            .map(SyntaxNode::from)
     }
 }
 
@@ -482,30 +463,11 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
 }
 
 impl<L: Language> SyntaxElementChildren<L> {
-    pub fn by_kind<'a>(
+    pub fn by_kind(
         self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxElementChildrenByKind<'a, L> {
-        SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxElementChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxElementChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxElementChildrenByKind<'a, L> {
-    type Item = SyntaxElement<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(NodeOrToken::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxElementChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxElementChildrenByKind").finish()
+        matcher: impl Fn(L::Kind) -> bool,
+    ) -> impl Iterator<Item = SyntaxElement<L>> {
+        self.raw.by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind))).map(NodeOrToken::from)
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -256,8 +256,12 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.detach()
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement<L>>) {
-        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from).collect::<Vec<_>>();
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement<L>>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
+        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from);
         self.raw.splice_children(to_delete, to_insert)
     }
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,12 +1,13 @@
-use std::{borrow::Cow, fmt, iter, marker::PhantomData, ops::Range};
+use alloc::borrow::Cow;
+use core::{fmt, hash::Hash, iter, marker::PhantomData, ops::Range};
 
 use crate::{
     Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken, SyntaxKind, SyntaxText,
     TextRange, TextSize, TokenAtOffset, WalkEvent, cursor, green::GreenTokenData,
 };
 
-pub trait Language: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
-    type Kind: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash;
+pub trait Language: Sized + Copy + fmt::Debug + Eq + Ord + Hash {
+    type Kind: Sized + Copy + fmt::Debug + Eq + Ord + Hash;
 
     fn kind_from_raw(raw: SyntaxKind) -> Self::Kind;
     fn kind_to_raw(kind: Self::Kind) -> SyntaxKind;
@@ -68,7 +69,7 @@ impl<L: Language> fmt::Debug for SyntaxToken<L> {
         let text = self.text();
         for idx in 21..25 {
             if text.is_char_boundary(idx) {
-                let text = format!("{} ...", &text[..idx]);
+                let text = alloc::format!("{} ...", &text[..idx]);
                 return write!(f, " {:?}", text);
             }
         }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -83,7 +83,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        std::ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, offset_of, ManuallyDrop},
+    mem::{self, ManuallyDrop, offset_of},
     ops::Deref,
     ptr,
     sync::atomic::{
@@ -55,14 +55,17 @@ impl<T> Arc<T> {
     pub(crate) unsafe fn from_raw(ptr: *const T) -> Self {
         // To find the corresponding pointer to the `ArcInner` we need
         // to subtract the offset of the `data` field from the pointer.
-        let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
-        Arc { p: ptr::NonNull::new_unchecked(ptr as *mut ArcInner<T>), phantom: PhantomData }
+        unsafe {
+            let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
+            Arc { p: ptr::NonNull::new_unchecked(ptr as *mut ArcInner<T>), phantom: PhantomData }
+        }
     }
 }
 
 impl<T: ?Sized> Arc<T> {
     #[inline]
     fn inner(&self) -> &ArcInner<T> {
+        // SAFETY:
         // This unsafety is ok because while this arc is alive we're guaranteed
         // that the inner pointer is valid. Furthermore, we know that the
         // `ArcInner` structure itself is `Sync` because the inner data is
@@ -74,7 +77,9 @@ impl<T: ?Sized> Arc<T> {
     // Non-inlined part of `drop`. Just invokes the destructor.
     #[inline(never)]
     unsafe fn drop_slow(&mut self) {
-        let _ = Box::from_raw(self.ptr());
+        unsafe {
+            let _ = Box::from_raw(self.ptr());
+        }
     }
 
     /// Test pointer equality between the two Arcs, i.e. they must be the _same_
@@ -195,10 +200,6 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     fn eq(&self, other: &Arc<T>) -> bool {
         Self::ptr_eq(self, other) || *(*self) == *(*other)
     }
-
-    fn ne(&self, other: &Arc<T>) -> bool {
-        !Self::ptr_eq(self, other) && *(*self) != *(*other)
-    }
 }
 
 impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
@@ -312,10 +313,7 @@ impl<H, T> ThinArc<H, T> {
         };
 
         // Expose the transient Arc to the callback, which may clone it if it wants.
-        let result = f(&transient);
-
-        // Forward the result.
-        result
+        f(&transient)
     }
 
     /// Creates a `ThinArc` for a HeaderSlice using the given header struct and

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,12 +257,10 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
             let len = self.length;
             let fake_slice: *const [T] =
                 ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            &*(fake_slice as *const HeaderSlice<H, [T]>)
-        }
+            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, ManuallyDrop},
+    mem::{self, offset_of, ManuallyDrop},
     ops::Deref,
     ptr,
     sync::atomic::{
@@ -12,8 +12,6 @@ use std::{
         Ordering::{Acquire, Relaxed, Release},
     },
 };
-
-use memoffset::offset_of;
 
 /// A soft limit on the amount of references that may be made to an `Arc`.
 ///

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,10 +257,9 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-            let len = self.length;
-            let fake_slice: *const [T] =
-                ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
+        let len = self.length;
+        let fake_slice: *const [T] = ptr::slice_from_raw_parts(self as *const _ as *const T, len);
+        unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -1,6 +1,7 @@
 //! Vendored and stripped down version of triomphe
-use std::{
-    alloc::{self, Layout},
+use crate::alloc::alloc::{self, Layout};
+use crate::alloc::boxed::Box;
+use core::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
@@ -86,7 +87,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        std::ptr::addr_eq(this.ptr(), other.ptr())
+        ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {
@@ -120,7 +121,7 @@ impl<T: ?Sized> Clone for Arc<T> {
         // We abort because such a program is incredibly degenerate, and we
         // don't care to support it.
         if old_size > MAX_REFCOUNT {
-            std::process::abort();
+            panic!("Arc reference count overflow");
         }
 
         unsafe { Arc { p: ptr::NonNull::new_unchecked(self.ptr()), phantom: PhantomData } }

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -156,7 +156,7 @@ impl<N: AstNode> AstPtr<N> {
 
     /// Returns the underlying [`SyntaxNodePtr`].
     pub fn syntax_node_ptr(&self) -> SyntaxNodePtr<N::Language> {
-        self.raw.clone()
+        self.raw
     }
 
     /// Casts this to an [`AstPtr`] to the given node type if possible.
@@ -176,7 +176,7 @@ impl<N: AstNode> fmt::Debug for AstPtr<N> {
 
 impl<N: AstNode> Clone for AstPtr<N> {
     fn clone(&self) -> Self {
-        Self { raw: self.raw.clone() }
+        Self { raw: self.raw }
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -13,7 +13,7 @@
 //! We also provide an [`AstNode`] trait for typed AST wrapper APIs over rowan
 //! nodes.
 
-use std::{
+use core::{
     fmt,
     hash::{Hash, Hasher},
     iter::successors,

--- a/src/countme.rs
+++ b/src/countme.rs
@@ -1,0 +1,13 @@
+use core::marker::PhantomData;
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct Count<T: 'static> {
+    marker: PhantomData<fn(T)>,
+}
+
+impl<T: 'static> Count<T> {
+    #[inline]
+    pub(crate) const fn new() -> Self {
+        Self { marker: PhantomData }
+    }
+}

--- a/src/cow_mut.rs
+++ b/src/cow_mut.rs
@@ -9,7 +9,7 @@ impl<T> std::ops::Deref for CowMut<'_, T> {
     fn deref(&self) -> &T {
         match self {
             CowMut::Owned(it) => it,
-            CowMut::Borrowed(it) => *it,
+            CowMut::Borrowed(it) => it,
         }
     }
 }
@@ -18,7 +18,7 @@ impl<T> std::ops::DerefMut for CowMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         match self {
             CowMut::Owned(it) => it,
-            CowMut::Borrowed(it) => *it,
+            CowMut::Borrowed(it) => it,
         }
     }
 }

--- a/src/cow_mut.rs
+++ b/src/cow_mut.rs
@@ -1,10 +1,12 @@
+use core::ops::{Deref, DerefMut};
+
 #[derive(Debug)]
 pub(crate) enum CowMut<'a, T> {
     Owned(T),
     Borrowed(&'a mut T),
 }
 
-impl<T> std::ops::Deref for CowMut<'_, T> {
+impl<T> Deref for CowMut<'_, T> {
     type Target = T;
     fn deref(&self) -> &T {
         match self {
@@ -14,7 +16,7 @@ impl<T> std::ops::Deref for CowMut<'_, T> {
     }
 }
 
-impl<T> std::ops::DerefMut for CowMut<'_, T> {
+impl<T> DerefMut for CowMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         match self {
             CowMut::Owned(it) => it,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -668,7 +668,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), SyntaxNode::parent)
     }
 
@@ -831,7 +831,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), move |node| match direction {
             Direction::Next => node.next_sibling(),
             Direction::Prev => node.prev_sibling(),
@@ -842,7 +842,7 @@ impl SyntaxNode {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let me: SyntaxElement = self.clone().into();
         iter::successors(Some(me), move |el| match direction {
             Direction::Next => el.next_sibling_or_token(),
@@ -851,7 +851,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         self.preorder().filter_map(|event| match event {
             WalkEvent::Enter(node) => Some(node),
             WalkEvent::Leave(_) => None,
@@ -859,7 +859,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> {
+    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> + use<> {
         self.preorder_with_tokens().filter_map(|event| match event {
             WalkEvent::Enter(it) => Some(it),
             WalkEvent::Leave(_) => None,
@@ -1054,7 +1054,7 @@ impl SyntaxToken {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         std::iter::successors(self.parent(), SyntaxNode::parent)
     }
 
@@ -1077,7 +1077,7 @@ impl SyntaxToken {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let me: SyntaxElement = self.clone().into();
         iter::successors(Some(me), move |el| match direction {
             Direction::Next => el.next_sibling_or_token(),
@@ -1156,7 +1156,7 @@ impl SyntaxElement {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1474,6 +1474,7 @@ impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxElementChildrenByKind<F> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder {
     start: SyntaxNode,
     next: Option<WalkEvent<SyntaxNode>>,
@@ -1529,6 +1530,7 @@ impl Iterator for Preorder {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens {
     start: SyntaxElement,
     next: Option<WalkEvent<SyntaxElement>>,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -408,7 +408,7 @@ impl NodeData {
         let rev_siblings = self.green_siblings().enumerate().rev();
         let index = rev_siblings.len().checked_sub(self.index() as usize)?;
 
-        rev_siblings.skip(index + 1).find_map(|(index, child)| {
+        rev_siblings.skip(index).find_map(|(index, child)| {
             child.as_ref().into_node().and_then(|green| {
                 let parent = self.parent_node()?;
                 let offset = parent.offset() + child.rel_offset();

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -544,6 +544,10 @@ impl SyntaxNode {
         SyntaxNode { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.data().mutable
+    }
+
     pub fn clone_for_update(&self) -> SyntaxNode {
         assert!(!self.data().mutable);
         match self.parent() {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -806,7 +806,11 @@ impl SyntaxNode {
         })
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement>) {
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
         assert!(self.data().mutable, "immutable tree: {}", self);
         for (i, child) in self.children_with_tokens().enumerate() {
             if to_delete.contains(&i) {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -790,6 +790,7 @@ impl SyntaxNode {
                 Some(SyntaxNode { ptr })
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })
@@ -1234,6 +1235,7 @@ impl SyntaxElement {
                 }
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -478,7 +478,7 @@ impl NodeData {
 
         match self.green() {
             NodeOrToken::Node(green) => {
-                // Child is root, so it ownes the green node. Steal it!
+                // Child is root, so it owns the green node. Steal it!
                 let child_green = match &child.green {
                     Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.get()).into() },
                     Green::Token { ptr } => unsafe { GreenToken::from_raw(*ptr).into() },

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -81,8 +81,12 @@
 //      when the tree is mutable.
 //    - TBD
 
-use std::{
-    borrow::Cow,
+use alloc::{
+    borrow::{Cow, ToOwned},
+    boxed::Box,
+    string::ToString,
+};
+use core::{
     cell::Cell,
     fmt,
     hash::{Hash, Hasher},
@@ -92,11 +96,10 @@ use std::{
     ptr, slice,
 };
 
-use countme::Count;
-
 use crate::{
     Direction, GreenNode, GreenToken, NodeOrToken, SyntaxText, TextRange, TextSize, TokenAtOffset,
     WalkEvent,
+    countme::Count,
     green::{GreenChild, GreenElementRef, GreenNodeData, GreenTokenData, SyntaxKind},
     sll,
     utility_types::Delta,
@@ -285,7 +288,7 @@ impl NodeData {
     fn inc_rc(&self) {
         let rc = match self.rc.get().checked_add(1) {
             Some(it) => it,
-            None => std::process::abort(),
+            None => panic!("reference count overflow"),
         };
         self.rc.set(rc)
     }
@@ -327,7 +330,7 @@ impl NodeData {
         }
     }
     #[inline]
-    fn green_siblings(&self) -> slice::Iter<GreenChild> {
+    fn green_siblings(&self) -> slice::Iter<'_, GreenChild> {
         match &self.parent().map(|it| &it.green) {
             Some(Green::Node { ptr }) => unsafe { &*ptr.get().as_ptr() }.children().raw,
             Some(Green::Token { .. }) => {
@@ -607,7 +610,7 @@ impl SyntaxNode {
         assert!(self.can_take_ptr());
         let ret = self.ptr;
         // don't change the refcount when self gets dropped
-        std::mem::forget(self);
+        mem::forget(self);
         ret
     }
 
@@ -1000,7 +1003,7 @@ impl SyntaxToken {
         assert!(self.can_take_ptr());
         let ret = self.ptr;
         // don't change the refcount when self gets dropped
-        std::mem::forget(self);
+        mem::forget(self);
         ret
     }
 
@@ -1055,7 +1058,7 @@ impl SyntaxToken {
 
     #[inline]
     pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
-        std::iter::successors(self.parent(), SyntaxNode::parent)
+        iter::successors(self.parent(), SyntaxNode::parent)
     }
 
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {

--- a/src/green.rs
+++ b/src/green.rs
@@ -33,10 +33,10 @@ mod tests {
 
     #[test]
     fn test_size_of() {
-        use std::mem::size_of;
+        use core::mem::size_of;
 
-        eprintln!("GreenNode          {}", size_of::<GreenNode>());
-        eprintln!("GreenToken         {}", size_of::<GreenToken>());
-        eprintln!("GreenElement       {}", size_of::<GreenElement>());
+        std::eprintln!("GreenNode          {}", size_of::<GreenNode>());
+        std::eprintln!("GreenToken         {}", size_of::<GreenToken>());
+        std::eprintln!("GreenElement       {}", size_of::<GreenElement>());
     }
 }

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,9 +1,9 @@
 use std::num::NonZeroUsize;
 
 use crate::{
-    cow_mut::CowMut,
-    green::{node_cache::NodeCache, GreenElement, GreenNode, SyntaxKind},
     NodeOrToken,
+    cow_mut::CowMut,
+    green::{GreenElement, GreenNode, SyntaxKind, node_cache::NodeCache},
 };
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,4 +1,5 @@
-use std::num::NonZeroUsize;
+use alloc::vec::Vec;
+use core::num::NonZeroUsize;
 
 use crate::{
     NodeOrToken,

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::{
-    green::{GreenNode, GreenToken, SyntaxKind},
     GreenNodeData, NodeOrToken, TextSize,
+    green::{GreenNode, GreenToken, SyntaxKind},
 };
 
 use super::GreenTokenData;

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use alloc::borrow::{Cow, ToOwned};
 
 use crate::{
     GreenNodeData, NodeOrToken, TextSize,

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -12,7 +12,6 @@ use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::{GreenElement, GreenElementRef, SyntaxKind},
-    utility_types::static_assert,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,8 +27,6 @@ pub(crate) enum GreenChild {
     Node { rel_offset: TextSize, node: GreenNode },
     Token { rel_offset: TextSize, token: GreenToken },
 }
-#[cfg(target_pointer_width = "64")]
-static_assert!(mem::size_of::<GreenChild>() == mem::size_of::<usize>() * 2);
 
 type Repr = HeaderSlice<GreenNodeHead, [GreenChild]>;
 type ReprThin = HeaderSlice<GreenNodeHead, [GreenChild; 0]>;
@@ -356,3 +353,16 @@ impl DoubleEndedIterator for Children<'_> {
 }
 
 impl FusedIterator for Children<'_> {}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn check_green_child_size() {
+        use super::GreenChild;
+        use std::mem;
+
+        assert_eq!(mem::size_of::<GreenChild>(), mem::size_of::<usize>() * 2);
+    }
+}

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -9,10 +9,10 @@ use std::{
 use countme::Count;
 
 use crate::{
+    GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::{GreenElement, GreenElementRef, SyntaxKind},
     utility_types::static_assert,
-    GreenToken, NodeOrToken, TextRange, TextSize,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,7 +66,7 @@ impl ToOwned for GreenNodeData {
 impl Borrow<GreenNodeData> for GreenNode {
     #[inline]
     fn borrow(&self) -> &GreenNodeData {
-        &*self
+        self
     }
 }
 
@@ -89,14 +89,14 @@ impl fmt::Debug for GreenNodeData {
 
 impl fmt::Debug for GreenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenNodeData = &*self;
+        let data: &GreenNodeData = self;
         fmt::Debug::fmt(data, f)
     }
 }
 
 impl fmt::Display for GreenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenNodeData = &*self;
+        let data: &GreenNodeData = self;
         fmt::Display::fmt(data, f)
     }
 }
@@ -159,11 +159,7 @@ impl GreenNodeData {
     pub fn replace_child(&self, index: usize, new_child: GreenElement) -> GreenNode {
         let mut replacement = Some(new_child);
         let children = self.children().enumerate().map(|(i, child)| {
-            if i == index {
-                replacement.take().unwrap()
-            } else {
-                child.to_owned()
-            }
+            if i == index { replacement.take().unwrap() } else { child.to_owned() }
         });
         GreenNode::new(self.kind(), children)
     }
@@ -238,15 +234,17 @@ impl GreenNode {
     #[inline]
     pub(crate) fn into_raw(this: GreenNode) -> ptr::NonNull<GreenNodeData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenNodeData = &*green;
-        ptr::NonNull::from(&*green)
+        let green: &GreenNodeData = &green;
+        ptr::NonNull::from(green)
     }
 
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenNodeData>) -> GreenNode {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, GreenChild>>(arc);
-        GreenNode { ptr: arc }
+        unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, GreenChild>>(arc);
+            GreenNode { ptr: arc }
+        }
     }
 }
 
@@ -321,19 +319,19 @@ impl<'a> Iterator for Children<'a> {
     }
 
     #[inline]
-    fn fold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
     where
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut accum = init;
-        while let Some(x) = self.next() {
+        for x in self {
             accum = f(accum, x);
         }
         accum
     }
 }
 
-impl<'a> DoubleEndedIterator for Children<'a> {
+impl DoubleEndedIterator for Children<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.raw.next_back().map(GreenChild::as_ref)

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -23,6 +23,7 @@ pub(super) struct GreenNodeHead {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub(crate) enum GreenChild {
     Node { rel_offset: TextSize, node: GreenNode },
     Token { rel_offset: TextSize, token: GreenToken },

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,11 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-        unsafe {
-            let green = GreenNode::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenNode::clone(&green)
-        }
     }
 }
 
@@ -194,8 +192,8 @@ impl ops::Deref for GreenNode {
 
     #[inline]
     fn deref(&self) -> &GreenNodeData {
+        let repr: &Repr = &self.ptr;
         unsafe {
-            let repr: &Repr = &self.ptr;
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenNodeData>(repr)
         }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,9 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenNode::clone(&green)
+        let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenNode::clone(&green)
     }
 }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -1,16 +1,19 @@
-use std::{
-    borrow::{Borrow, Cow},
+use alloc::{
+    borrow::{Cow, ToOwned},
+    vec::Vec,
+};
+use core::{
+    borrow::Borrow,
     fmt,
     iter::{self, FusedIterator},
     mem::{self, ManuallyDrop},
     ops, ptr, slice,
 };
 
-use countme::Count;
-
 use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
+    countme::Count,
     green::{GreenElement, GreenElementRef, SyntaxKind},
 };
 
@@ -247,7 +250,7 @@ impl GreenNode {
 
 impl GreenChild {
     #[inline]
-    pub(crate) fn as_ref(&self) -> GreenElementRef {
+    pub(crate) fn as_ref(&self) -> GreenElementRef<'_> {
         match self {
             GreenChild::Node { node, .. } => NodeOrToken::Node(node),
             GreenChild::Token { token, .. } => NodeOrToken::Token(token),
@@ -361,7 +364,7 @@ mod test {
     #[cfg(target_pointer_width = "64")]
     fn check_green_child_size() {
         use super::GreenChild;
-        use std::mem;
+        use core::mem;
 
         assert_eq!(mem::size_of::<GreenChild>(), mem::size_of::<usize>() * 2);
     }

--- a/src/green/node_cache.rs
+++ b/src/green/node_cache.rs
@@ -3,8 +3,8 @@ use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 
 use crate::{
-    green::GreenElementRef, GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken,
-    SyntaxKind,
+    GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken, SyntaxKind,
+    green::GreenElementRef,
 };
 
 use super::element::GreenElement;

--- a/src/green/node_cache.rs
+++ b/src/green/node_cache.rs
@@ -1,6 +1,7 @@
+use alloc::vec::Vec;
+use core::hash::{BuildHasherDefault, Hash, Hasher};
 use hashbrown::hash_map::RawEntryMut;
 use rustc_hash::FxHasher;
-use std::hash::{BuildHasherDefault, Hash, Hasher};
 
 use crate::{
     GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken, SyntaxKind,

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,9 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenToken::clone(&green)
+        let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenToken::clone(&green)
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,11 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-        unsafe {
-            let green = GreenToken::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenToken::clone(&green)
-        }
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -8,9 +8,9 @@ use std::{
 use countme::Count;
 
 use crate::{
+    TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::SyntaxKind,
-    TextSize,
 };
 
 #[derive(PartialEq, Eq, Hash)]
@@ -53,7 +53,7 @@ impl ToOwned for GreenTokenData {
 impl Borrow<GreenTokenData> for GreenToken {
     #[inline]
     fn borrow(&self) -> &GreenTokenData {
-        &*self
+        self
     }
 }
 
@@ -68,14 +68,14 @@ impl fmt::Debug for GreenTokenData {
 
 impl fmt::Debug for GreenToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenTokenData = &*self;
+        let data: &GreenTokenData = self;
         fmt::Debug::fmt(data, f)
     }
 }
 
 impl fmt::Display for GreenToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenTokenData = &*self;
+        let data: &GreenTokenData = self;
         fmt::Display::fmt(data, f)
     }
 }
@@ -117,14 +117,25 @@ impl GreenToken {
     #[inline]
     pub(crate) fn into_raw(this: GreenToken) -> ptr::NonNull<GreenTokenData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenTokenData = &*green;
-        ptr::NonNull::from(&*green)
+        let green: &GreenTokenData = &green;
+        ptr::NonNull::from(green)
     }
 
+    /// # Safety
+    ///
+    /// This function uses `unsafe` code to create an `Arc` from a raw pointer and then transmutes it into a `ThinArc`.
+    ///
+    /// - The raw pointer must be valid and correctly aligned for the type `ReprThin`.
+    /// - The lifetime of the raw pointer must outlive the lifetime of the `Arc` created from it.
+    /// - The transmute operation must be safe, meaning that the memory layout of `Arc<ReprThin>` must be compatible with `ThinArc<GreenTokenHead, u8>`.
+    ///
+    /// Failure to uphold these invariants can lead to undefined behavior.
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenTokenData>) -> GreenToken {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc);
+        let arc = unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc)
+        };
         GreenToken { ptr: arc }
     }
 }

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -1,15 +1,15 @@
-use std::{
+use alloc::borrow::ToOwned;
+use core::{
     borrow::Borrow,
     fmt,
     mem::{self, ManuallyDrop},
     ops, ptr,
 };
 
-use countme::Count;
-
 use crate::{
     TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
+    countme::Count,
     green::SyntaxKind,
 };
 
@@ -96,7 +96,7 @@ impl GreenTokenData {
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &str {
-        unsafe { std::str::from_utf8_unchecked(self.data.slice()) }
+        unsafe { core::str::from_utf8_unchecked(self.data.slice()) }
     }
 
     /// Returns the length of the text covered by this token.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
-        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
+        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! A generic library for lossless syntax trees.
 //! See `examples/s_expressions.rs` for a tutorial.
+#![no_std]
 #![forbid(
     // missing_debug_implementations,
     unconditional_recursion,
@@ -8,13 +9,19 @@
 )]
 #![deny(unsafe_code)]
 
+extern crate alloc;
+#[cfg(test)]
+extern crate std;
+
 #[allow(unsafe_code)]
 mod green;
 #[allow(unsafe_code)]
 pub mod cursor;
 
 pub mod api;
+mod countme;
 mod syntax_text;
+mod text_size;
 mod utility_types;
 
 mod cow_mut;
@@ -26,7 +33,7 @@ mod arc;
 mod serde_impls;
 pub mod ast;
 
-pub use text_size::{TextLen, TextRange, TextSize};
+pub use crate::text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -2,8 +2,8 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{
-    api::{Language, SyntaxNode, SyntaxToken},
     NodeOrToken,
+    api::{Language, SyntaxNode, SyntaxToken},
 };
 
 struct SerDisplay<T>(T);

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -1,5 +1,5 @@
+use core::fmt;
 use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
-use std::fmt;
 
 use crate::{
     NodeOrToken,

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -3,6 +3,15 @@
 use std::{cell::Cell, cmp::Ordering, ptr};
 
 use crate::utility_types::Delta;
+
+/// # Safety
+///
+/// Implementors of this trait must ensure that the pointers returned by
+/// `prev` and `next` are valid and properly initialized. The pointers must
+/// point to valid instances of the implementing type or be null pointers.
+/// Additionally, the `key` method must return a valid reference to a `Cell<u32>`.
+///
+/// Failure to uphold these invariants can result in undefined behavior.
 pub(crate) unsafe trait Elem {
     fn prev(&self) -> &Cell<*const Self>;
     fn next(&self) -> &Cell<*const Self>;
@@ -17,7 +26,7 @@ pub(crate) enum AddToSllResult<'a, E: Elem> {
     AlreadyInSll(*const E),
 }
 
-impl<'a, E: Elem> AddToSllResult<'a, E> {
+impl<E: Elem> AddToSllResult<'_, E> {
     pub(crate) fn add_to_sll(&self, elem_ptr: *const E) {
         unsafe {
             (*elem_ptr).prev().set(elem_ptr);
@@ -55,11 +64,7 @@ pub(crate) fn init<'a, E: Elem>(
     head: Option<&'a Cell<*const E>>,
     elem: &E,
 ) -> AddToSllResult<'a, E> {
-    if let Some(head) = head {
-        link(head, elem)
-    } else {
-        AddToSllResult::NoHead
-    }
+    if let Some(head) = head { link(head, elem) } else { AddToSllResult::NoHead }
 }
 
 #[cold]

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -90,7 +90,6 @@ pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllR
         return AddToSllResult::EmptyHead(head);
     }
     unsafe {
-
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {
             return AddToSllResult::SmallerThanHead(head);

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -84,12 +84,12 @@ pub(crate) fn unlink<E: Elem>(head: &Cell<*const E>, elem: &E) {
 
 #[cold]
 pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllResult<'a, E> {
+    let old_head = head.get();
+    // Case 1: empty head, replace it.
+    if old_head.is_null() {
+        return AddToSllResult::EmptyHead(head);
+    }
     unsafe {
-        let old_head = head.get();
-        // Case 1: empty head, replace it.
-        if old_head.is_null() {
-            return AddToSllResult::EmptyHead(head);
-        }
 
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -1,6 +1,6 @@
 //! Sorted Linked List
 
-use std::{cell::Cell, cmp::Ordering, ptr};
+use core::{cell::Cell, cmp::Ordering, ptr};
 
 use crate::utility_types::Delta;
 

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -105,7 +105,7 @@ impl SyntaxText {
         }
     }
 
-    fn tokens_with_ranges(&self) -> impl Iterator<Item = (SyntaxToken, TextRange)> {
+    fn tokens_with_ranges(&self) -> impl Iterator<Item = (SyntaxToken, TextRange)> + use<> {
         let text_range = self.range;
         self.node.descendants_with_tokens().filter_map(|element| element.into_token()).filter_map(
             move |token| {

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -1,4 +1,5 @@
-use std::fmt;
+use alloc::string::{String, ToString};
+use core::{cmp, fmt};
 
 use crate::{
     TextRange, TextSize,
@@ -202,7 +203,7 @@ fn zip_texts<I: Iterator<Item = (SyntaxToken, TextRange)>>(xs: &mut I, ys: &mut 
         if !(x_text.starts_with(y_text) || y_text.starts_with(x_text)) {
             return Some(());
         }
-        let advance = std::cmp::min(x.1.len(), y.1.len());
+        let advance = cmp::min(x.1.len(), y.1.len());
         x.1 = TextRange::new(x.1.start() + advance, x.1.end());
         y.1 = TextRange::new(y.1.start() + advance, y.1.end());
     }
@@ -211,7 +212,7 @@ fn zip_texts<I: Iterator<Item = (SyntaxToken, TextRange)>>(xs: &mut I, ys: &mut 
 impl Eq for SyntaxText {}
 
 mod private {
-    use std::ops;
+    use core::ops;
 
     use crate::{TextRange, TextSize};
 

--- a/src/text_size.rs
+++ b/src/text_size.rs
@@ -1,0 +1,470 @@
+use alloc::string::String;
+use core::{
+    cmp::{self, Ordering},
+    convert::{TryFrom, TryInto},
+    fmt, iter,
+    num::TryFromIntError,
+    ops::{Add, AddAssign, Bound, Index, IndexMut, Range, RangeBounds, Sub, SubAssign},
+};
+
+#[cfg(target_pointer_width = "16")]
+compile_error!("text-size assumes usize >= u32 and does not work on 16-bit targets");
+
+#[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TextSize {
+    raw: u32,
+}
+
+impl fmt::Debug for TextSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw)
+    }
+}
+
+impl TextSize {
+    #[inline]
+    pub const fn new(raw: u32) -> TextSize {
+        TextSize { raw }
+    }
+
+    #[inline]
+    pub fn of<T: TextLen>(text: T) -> TextSize {
+        text.text_len()
+    }
+
+    #[inline]
+    pub const fn checked_add(self, rhs: TextSize) -> Option<TextSize> {
+        match self.raw.checked_add(rhs.raw) {
+            Some(raw) => Some(TextSize { raw }),
+            None => None,
+        }
+    }
+
+    #[inline]
+    pub const fn checked_sub(self, rhs: TextSize) -> Option<TextSize> {
+        match self.raw.checked_sub(rhs.raw) {
+            Some(raw) => Some(TextSize { raw }),
+            None => None,
+        }
+    }
+}
+
+impl From<u32> for TextSize {
+    #[inline]
+    fn from(raw: u32) -> Self {
+        TextSize { raw }
+    }
+}
+
+impl From<TextSize> for u32 {
+    #[inline]
+    fn from(value: TextSize) -> Self {
+        value.raw
+    }
+}
+
+impl TryFrom<usize> for TextSize {
+    type Error = TryFromIntError;
+
+    #[inline]
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Ok(u32::try_from(value)?.into())
+    }
+}
+
+impl From<TextSize> for usize {
+    #[inline]
+    fn from(value: TextSize) -> Self {
+        value.raw as usize
+    }
+}
+
+macro_rules! text_size_ops {
+    (impl $op:ident for TextSize by fn $fn:ident = $symbol:tt) => {
+        impl $op<TextSize> for TextSize {
+            type Output = TextSize;
+
+            #[inline]
+            fn $fn(self, other: TextSize) -> TextSize {
+                TextSize { raw: self.raw $symbol other.raw }
+            }
+        }
+
+        impl $op<&TextSize> for TextSize {
+            type Output = TextSize;
+
+            #[inline]
+            fn $fn(self, other: &TextSize) -> TextSize {
+                self $symbol *other
+            }
+        }
+
+        impl<T> $op<T> for &TextSize
+        where
+            TextSize: $op<T, Output = TextSize>,
+        {
+            type Output = TextSize;
+
+            #[inline]
+            fn $fn(self, other: T) -> TextSize {
+                *self $symbol other
+            }
+        }
+    };
+}
+
+text_size_ops!(impl Add for TextSize by fn add = +);
+text_size_ops!(impl Sub for TextSize by fn sub = -);
+
+impl<A> AddAssign<A> for TextSize
+where
+    TextSize: Add<A, Output = TextSize>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: A) {
+        *self = *self + rhs;
+    }
+}
+
+impl<S> SubAssign<S> for TextSize
+where
+    TextSize: Sub<S, Output = TextSize>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: S) {
+        *self = *self - rhs;
+    }
+}
+
+impl<A> iter::Sum<A> for TextSize
+where
+    TextSize: Add<A, Output = TextSize>,
+{
+    #[inline]
+    fn sum<I: Iterator<Item = A>>(iter: I) -> TextSize {
+        iter.fold(0.into(), Add::add)
+    }
+}
+
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash)]
+pub struct TextRange {
+    start: TextSize,
+    end: TextSize,
+}
+
+impl fmt::Debug for TextRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}..{}", self.start().raw, self.end().raw)
+    }
+}
+
+impl TextRange {
+    #[inline]
+    pub const fn new(start: TextSize, end: TextSize) -> TextRange {
+        assert!(start.raw <= end.raw);
+        TextRange { start, end }
+    }
+
+    #[inline]
+    pub const fn at(offset: TextSize, len: TextSize) -> TextRange {
+        TextRange::new(offset, TextSize::new(offset.raw + len.raw))
+    }
+
+    #[inline]
+    pub const fn empty(offset: TextSize) -> TextRange {
+        TextRange { start: offset, end: offset }
+    }
+
+    #[inline]
+    pub const fn up_to(end: TextSize) -> TextRange {
+        TextRange { start: TextSize::new(0), end }
+    }
+
+    #[inline]
+    pub const fn start(self) -> TextSize {
+        self.start
+    }
+
+    #[inline]
+    pub const fn end(self) -> TextSize {
+        self.end
+    }
+
+    #[inline]
+    pub const fn len(self) -> TextSize {
+        TextSize { raw: self.end().raw - self.start().raw }
+    }
+
+    #[inline]
+    pub const fn is_empty(self) -> bool {
+        self.start().raw == self.end().raw
+    }
+
+    #[inline]
+    pub fn contains(self, offset: TextSize) -> bool {
+        self.start() <= offset && offset < self.end()
+    }
+
+    #[inline]
+    pub fn contains_inclusive(self, offset: TextSize) -> bool {
+        self.start() <= offset && offset <= self.end()
+    }
+
+    #[inline]
+    pub fn contains_range(self, other: TextRange) -> bool {
+        self.start() <= other.start() && other.end() <= self.end()
+    }
+
+    #[inline]
+    pub fn intersect(self, other: TextRange) -> Option<TextRange> {
+        let start = cmp::max(self.start(), other.start());
+        let end = cmp::min(self.end(), other.end());
+        if end < start {
+            return None;
+        }
+        Some(TextRange::new(start, end))
+    }
+
+    #[inline]
+    pub fn cover(self, other: TextRange) -> TextRange {
+        let start = cmp::min(self.start(), other.start());
+        let end = cmp::max(self.end(), other.end());
+        TextRange::new(start, end)
+    }
+
+    #[inline]
+    pub fn cover_offset(self, offset: TextSize) -> TextRange {
+        self.cover(TextRange::empty(offset))
+    }
+
+    #[inline]
+    pub fn checked_add(self, offset: TextSize) -> Option<TextRange> {
+        Some(TextRange {
+            start: self.start.checked_add(offset)?,
+            end: self.end.checked_add(offset)?,
+        })
+    }
+
+    #[inline]
+    pub fn checked_sub(self, offset: TextSize) -> Option<TextRange> {
+        Some(TextRange {
+            start: self.start.checked_sub(offset)?,
+            end: self.end.checked_sub(offset)?,
+        })
+    }
+
+    #[inline]
+    pub fn ordering(self, other: TextRange) -> Ordering {
+        if self.end() <= other.start() {
+            Ordering::Less
+        } else if other.end() <= self.start() {
+            Ordering::Greater
+        } else {
+            Ordering::Equal
+        }
+    }
+}
+
+impl Index<TextRange> for str {
+    type Output = str;
+
+    #[inline]
+    fn index(&self, index: TextRange) -> &str {
+        &self[Range::<usize>::from(index)]
+    }
+}
+
+impl Index<TextRange> for String {
+    type Output = str;
+
+    #[inline]
+    fn index(&self, index: TextRange) -> &str {
+        &self[Range::<usize>::from(index)]
+    }
+}
+
+impl IndexMut<TextRange> for str {
+    #[inline]
+    fn index_mut(&mut self, index: TextRange) -> &mut str {
+        &mut self[Range::<usize>::from(index)]
+    }
+}
+
+impl IndexMut<TextRange> for String {
+    #[inline]
+    fn index_mut(&mut self, index: TextRange) -> &mut str {
+        &mut self[Range::<usize>::from(index)]
+    }
+}
+
+impl RangeBounds<TextSize> for TextRange {
+    fn start_bound(&self) -> Bound<&TextSize> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&TextSize> {
+        Bound::Excluded(&self.end)
+    }
+}
+
+impl<T> From<TextRange> for Range<T>
+where
+    T: From<TextSize>,
+{
+    #[inline]
+    fn from(range: TextRange) -> Self {
+        range.start().into()..range.end().into()
+    }
+}
+
+macro_rules! text_range_ops {
+    (impl $op:ident for TextRange by fn $fn:ident = $symbol:tt) => {
+        impl $op<&TextSize> for TextRange {
+            type Output = TextRange;
+
+            #[inline]
+            fn $fn(self, other: &TextSize) -> TextRange {
+                self $symbol *other
+            }
+        }
+
+        impl<T> $op<T> for &TextRange
+        where
+            TextRange: $op<T, Output = TextRange>,
+        {
+            type Output = TextRange;
+
+            #[inline]
+            fn $fn(self, other: T) -> TextRange {
+                *self $symbol other
+            }
+        }
+    };
+}
+
+impl Add<TextSize> for TextRange {
+    type Output = TextRange;
+
+    #[inline]
+    fn add(self, offset: TextSize) -> TextRange {
+        self.checked_add(offset).expect("TextRange +offset overflowed")
+    }
+}
+
+impl Sub<TextSize> for TextRange {
+    type Output = TextRange;
+
+    #[inline]
+    fn sub(self, offset: TextSize) -> TextRange {
+        self.checked_sub(offset).expect("TextRange -offset overflowed")
+    }
+}
+
+text_range_ops!(impl Add for TextRange by fn add = +);
+text_range_ops!(impl Sub for TextRange by fn sub = -);
+
+impl<A> AddAssign<A> for TextRange
+where
+    TextRange: Add<A, Output = TextRange>,
+{
+    #[inline]
+    fn add_assign(&mut self, rhs: A) {
+        *self = *self + rhs;
+    }
+}
+
+impl<S> SubAssign<S> for TextRange
+where
+    TextRange: Sub<S, Output = TextRange>,
+{
+    #[inline]
+    fn sub_assign(&mut self, rhs: S) {
+        *self = *self - rhs;
+    }
+}
+
+pub trait TextLen: Copy + private::Sealed {
+    fn text_len(self) -> TextSize;
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+impl private::Sealed for &'_ str {}
+
+impl TextLen for &'_ str {
+    #[inline]
+    fn text_len(self) -> TextSize {
+        self.len().try_into().unwrap()
+    }
+}
+
+impl private::Sealed for &'_ String {}
+
+impl TextLen for &'_ String {
+    #[inline]
+    fn text_len(self) -> TextSize {
+        self.as_str().text_len()
+    }
+}
+
+impl private::Sealed for char {}
+
+impl TextLen for char {
+    #[inline]
+    fn text_len(self) -> TextSize {
+        (self.len_utf8() as u32).into()
+    }
+}
+
+#[cfg(feature = "serde1")]
+mod serde_impls {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    use crate::{TextRange, TextSize};
+
+    impl Serialize for TextSize {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            u32::from(*self).serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for TextSize {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            u32::deserialize(deserializer).map(TextSize::from)
+        }
+    }
+
+    impl Serialize for TextRange {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            (self.start(), self.end()).serialize(serializer)
+        }
+    }
+
+    impl<'de> Deserialize<'de> for TextRange {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            let (start, end) = <(TextSize, TextSize)>::deserialize(deserializer)?;
+            if start > end {
+                return Err(de::Error::custom(alloc::format!(
+                    "invalid range: {:?}..{:?}",
+                    start,
+                    end
+                )));
+            }
+            Ok(TextRange::new(start, end))
+        }
+    }
+}

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -43,8 +43,8 @@ impl<N, T> NodeOrToken<N, T> {
 impl<N: Deref, T: Deref> NodeOrToken<N, T> {
     pub(crate) fn as_deref(&self) -> NodeOrToken<&N::Target, &T::Target> {
         match self {
-            NodeOrToken::Node(node) => NodeOrToken::Node(&*node),
-            NodeOrToken::Token(token) => NodeOrToken::Token(&*token),
+            NodeOrToken::Node(node) => NodeOrToken::Node(node),
+            NodeOrToken::Token(token) => NodeOrToken::Token(token),
         }
     }
 }

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -149,14 +149,6 @@ impl<T> Iterator for TokenAtOffset<T> {
 
 impl<T> ExactSizeIterator for TokenAtOffset<T> {}
 
-macro_rules! _static_assert {
-    ($expr:expr) => {
-        const _: i32 = 0 / $expr as i32;
-    };
-}
-
-pub(crate) use _static_assert as static_assert;
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum Delta<T> {
     Add(T),

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -1,8 +1,9 @@
-use std::{
-    fmt,
+use core::{
+    fmt, mem,
     ops::{AddAssign, Deref},
 };
-use text_size::TextSize;
+
+use crate::TextSize;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum NodeOrToken<N, T> {
@@ -125,7 +126,7 @@ impl<T> Iterator for TokenAtOffset<T> {
     type Item = T;
 
     fn next(&mut self) -> Option<T> {
-        match std::mem::replace(self, TokenAtOffset::None) {
+        match mem::replace(self, TokenAtOffset::None) {
             TokenAtOffset::None => None,
             TokenAtOffset::Single(node) => {
                 *self = TokenAtOffset::None;

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 xaction = "0.2"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,10 +3,8 @@ name = "xtask"
 version = "0.0.0"
 publish = false
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-xaction = "0.2"
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }
+anyhow = "1.0.96"
+xshell = "0.2.7"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,13 @@
-use std::env;
+use std::{
+    env,
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
+};
 
-use xaction::{cargo_toml, cmd, git, section, Result};
+use anyhow::anyhow;
+use xshell::{Shell, cmd};
+pub type Result<T> = anyhow::Result<T>;
 
 fn main() {
     if let Err(err) = try_main() {
@@ -9,42 +16,161 @@ fn main() {
     }
 }
 
+pub struct Section {
+    name: &'static str,
+    start: Instant,
+}
+
+pub struct CargoToml {
+    path: PathBuf,
+    contents: String,
+}
+
+impl CargoToml {
+    pub fn version(&self) -> Result<&str> {
+        self.get("version")
+    }
+
+    fn get(&self, field: &str) -> Result<&str> {
+        for line in self.contents.lines() {
+            let words = line.split_ascii_whitespace().collect::<Vec<_>>();
+            match words.as_slice() {
+                [n, "=", v, ..] if n.trim() == field => {
+                    assert!(v.starts_with('"') && v.ends_with('"'));
+                    return Ok(&v[1..v.len() - 1]);
+                }
+                _ => (),
+            }
+        }
+        Err(anyhow!("can't find `{}` in {}", field, self.path.display()))?
+    }
+
+    pub fn publish(&self, sh: &mut Shell) -> Result<()> {
+        let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
+        let dry_run = dry_run();
+        cmd!(sh, "cargo publish --token {token} {dry_run...}").run()?;
+        Ok(())
+    }
+
+    pub fn publish_all(&self, dirs: &[&str], sh: &mut Shell) -> Result<()> {
+        let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
+        if dry_run().is_none() {
+            for &dir in dirs {
+                for _ in 0..20 {
+                    std::thread::sleep(Duration::from_secs(10));
+                    if cmd!(
+                        sh,
+                        "cargo publish --manifest-path {dir}'/Cargo.toml' --token {token} --dry-run"
+                    )
+                    .run()
+                    .is_ok()
+                    {
+                        break;
+                    }
+                }
+                cmd!(sh, "cargo publish --manifest-path {dir}'/Cargo.toml' --token {token}")
+                    .run()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn dry_run() -> Option<&'static str> {
+    let dry_run = DRY_RUN.load(Ordering::Relaxed);
+    if dry_run { Some("--dry-run") } else { None }
+}
+
+pub fn section(name: &'static str) -> Section {
+    Section::new(name)
+}
+
+pub fn cargo_toml() -> Result<CargoToml> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let path = PathBuf::from(manifest_dir).join("Cargo.toml");
+    let contents = std::fs::read_to_string(&path)?;
+    Ok(CargoToml { path, contents })
+}
+
+static DRY_RUN: AtomicBool = AtomicBool::new(false);
+pub fn set_dry_run(yes: bool) {
+    DRY_RUN.store(yes, Ordering::Relaxed)
+}
+
 fn try_main() -> Result<()> {
+    let mut sh = Shell::new()?;
     let subcommand = std::env::args().nth(1);
     match subcommand {
         Some(it) if it == "ci" => (),
         _ => {
             print_usage();
-            Err("invalid arguments")?
+            Err(anyhow!("invalid arguments"))?
         }
     }
-
     let cargo_toml = cargo_toml()?;
-
-    {
-        let _s = section("BUILD");
-        cmd!("cargo test --workspace --no-run").run()?;
-    }
-
     {
         let _s = section("TEST");
-        cmd!("cargo test --workspace -- --nocapture").run()?;
+        for &release in &[None, Some("--release")] {
+            cmd!(sh, "cargo test {release...} --workspace -- --nocapture").run()?;
+        }
     }
 
     let version = cargo_toml.version()?;
     let tag = format!("v{}", version);
 
-    let dry_run =
-        env::var("CI").is_err() || git::has_tag(&tag)? || git::current_branch()? != "master";
-    xaction::set_dry_run(dry_run);
+    let dry_run = env::var("CI").is_err()
+        || git::has_tag(&tag, &mut sh)?
+        || git::current_branch(&mut sh)? != "master";
+    set_dry_run(dry_run);
 
     {
         let _s = section("PUBLISH");
-        cargo_toml.publish()?;
-        git::tag(&tag)?;
-        git::push_tags()?;
+        cargo_toml.publish(&mut sh)?;
+        git::tag(&tag, &mut sh)?;
+        git::push_tags(&mut sh)?;
     }
     Ok(())
+}
+
+pub mod git {
+    use xshell::{Shell, cmd};
+
+    use super::{Result, dry_run};
+
+    pub fn current_branch(sh: &mut Shell) -> Result<String> {
+        let res = cmd!(sh, "git branch --show-current").read()?;
+        Ok(res)
+    }
+
+    pub fn tag_list(sh: &mut Shell) -> Result<Vec<String>> {
+        let tags = cmd!(sh, "git tag --list").read()?;
+        let res = tags.lines().map(|it| it.trim().to_string()).collect();
+        Ok(res)
+    }
+
+    pub fn has_tag(tag: &str, sh: &mut Shell) -> Result<bool> {
+        let res = tag_list(sh)?.iter().any(|it| it == tag);
+        Ok(res)
+    }
+
+    pub fn tag(tag: &str, sh: &mut Shell) -> Result<()> {
+        if dry_run().is_some() {
+            return Ok(());
+        }
+        cmd!(sh, "git tag {tag}").run()?;
+        Ok(())
+    }
+
+    pub fn push_tags(sh: &mut Shell) -> Result<()> {
+        // `git push --tags --dry-run` exists, but it will fail with permissions
+        // error for forks.
+        if dry_run().is_some() {
+            return Ok(());
+        }
+
+        cmd!(sh, "git push --tags").run()?;
+        Ok(())
+    }
 }
 
 fn print_usage() {
@@ -56,4 +182,19 @@ SUBCOMMANDS:
     ci
 "
     )
+}
+
+impl Section {
+    fn new(name: &'static str) -> Section {
+        println!("::group::{}", name);
+        let start = Instant::now();
+        Section { name, start }
+    }
+}
+
+impl Drop for Section {
+    fn drop(&mut self) {
+        eprintln!("{}: {:.2?}", self.name, self.start.elapsed());
+        println!("::endgroup::");
+    }
 }

--- a/xtask/tests/tidy.rs
+++ b/xtask/tests/tidy.rs
@@ -1,6 +1,7 @@
-use xaction::cmd;
+use xshell::{Shell, cmd};
 
 #[test]
 fn test_formatting() {
-    cmd!("cargo fmt --all -- --check").run().unwrap()
+    let sh = Shell::new().unwrap();
+    cmd!(sh, "cargo fmt --all -- --check").run().unwrap()
 }


### PR DESCRIPTION
This PR makes `rowan` no-std + liballoc compatible.

Currently, it also inlines the `countme` and `text_size` crates into respective modules under `src`, as they are also `std`-bound when they don't need to be. Those can be removed once those modules are made no-std compatible.

I'm opening this since it is easy to do so, but given the current maintenance status, I'm not expecting that it is likely to be merged - that said, just ping me if you want any changes, and I'm happy to make them, or to rebase this on a newer branch if needed.

I plan to publish a fork of this crate containing these changes to unblock my own use case, but would like to stick with mainline if possible, so if this does get merged (or the rewrite is no-std + liballoc compatible), I'll retire that.