### PR TITLE
fix: reduce Miri UB in GreenNode/GreenToken deref and HeaderSlice

### DIFF
--- a/src/arc.rs
+++ b/src/arc.rs
@@ -252,13 +252,26 @@ impl<H, T> HeaderSlice<H, [T]> {
     }
 }
 
+impl<H, T> HeaderSlice<H, [T; 0]> {
+    /// Get a fat reference to the full HeaderSlice from raw pointer.
+    ///
+    /// # Safety
+    /// `ptr` must point to a valid `HeaderSlice<H, [T; 0]>` that was allocated
+    /// with space for `length` elements of `T` after the header.
+    pub(crate) unsafe fn as_fat_ref<'a>(ptr: *const Self) -> &'a HeaderSlice<H, [T]> {
+        let len = unsafe { (*ptr).length };
+        let fake_slice: *const [T] = ptr::slice_from_raw_parts(ptr as *const T, len);
+        unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
+    }
+}
+
 impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-        let len = self.length;
-        let fake_slice: *const [T] = ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-        unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
+        // Use raw pointer to avoid creating a reference with provenance
+        // limited to the thin [T; 0] type when the allocation is larger.
+        unsafe { Self::as_fat_ref(self as *const Self) }
     }
 }
 
@@ -279,7 +292,7 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
 /// via `HeaderSlice`.
 #[repr(transparent)]
 pub(crate) struct ThinArc<H, T> {
-    ptr: ptr::NonNull<ArcInner<HeaderSlice<H, [T; 0]>>>,
+    pub(crate) ptr: ptr::NonNull<ArcInner<HeaderSlice<H, [T; 0]>>>,
     phantom: PhantomData<(H, T)>,
 }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -186,10 +186,15 @@ impl ops::Deref for GreenNode {
 
     #[inline]
     fn deref(&self) -> &GreenNodeData {
-        let repr: &Repr = &self.ptr;
+        // SAFETY: GreenNodeData is #[repr(transparent)] over ReprThin,
+        // and ThinArc's inner pointer points to ArcInner<ReprThin>.
+        // We access the data field via raw pointer to avoid creating
+        // an intermediate fat reference that would need to be shrunk
+        // (which Miri flags as UB under stacked/tree borrows).
         unsafe {
-            let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
-            mem::transmute::<&ReprThin, &GreenNodeData>(repr)
+            let inner = self.ptr.ptr.as_ptr();
+            let data = ptr::addr_of!((*inner).data);
+            &*(data as *const ReprThin as *const GreenNodeData)
         }
     }
 }

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -145,10 +145,12 @@ impl ops::Deref for GreenToken {
 
     #[inline]
     fn deref(&self) -> &GreenTokenData {
+        // SAFETY: Same pattern as GreenNode::deref — access the thin
+        // data pointer directly to avoid fat→thin reference shrinking.
         unsafe {
-            let repr: &Repr = &self.ptr;
-            let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
-            mem::transmute::<&ReprThin, &GreenTokenData>(repr)
+            let inner = self.ptr.ptr.as_ptr();
+            let data = ptr::addr_of!((*inner).data);
+            &*(data as *const ReprThin as *const GreenTokenData)
         }
     }
 }


### PR DESCRIPTION
## Problem

Miri flags undefined behavior under both stacked borrows and tree borrows:

- `GreenNode::deref` and `GreenToken::deref` create `&Repr` (fat `HeaderSlice<H, [T]>`) via `ThinArc::deref`, then cast to `&ReprThin` (thin `HeaderSlice<H, [T; 0]>`) — creating a reference to a smaller type from a larger one
- `HeaderSlice<H, [T; 0]>::deref` takes `&self` whose provenance only covers the `[T; 0]` part, then creates a fat `&HeaderSlice<H, [T]>` that exceeds that provenance

Related: #192, #163, #108

## Fix

**Minimal changes to avoid the specific UB paths:**

1. `GreenNode::deref` / `GreenToken::deref`: Access the `ThinArc`'s inner pointer directly via `ptr::addr_of!` instead of going through the fat→thin reference chain
2. `HeaderSlice<H, [T; 0]>`: Extract `as_fat_ref` helper that takes a raw `*const Self` to avoid inheriting `&self`'s narrow provenance
3. `ThinArc::ptr` made `pub(crate)` for direct access from green node/token

## What this fixes

The `node_cache` and basic green tree construction paths now pass Miri cleanly. This covers the common usage pattern (parse → build green tree → query).

## What this doesn't fix

The cursor iteration path (`SyntaxText`, `PreorderWithTokens`) and mutable tree operations (`clone_for_update`) still have provenance issues from deeper in the cursor infrastructure. These need more extensive changes.

## Testing

- `cargo test` — all tests pass
- `cargo +nightly miri test -- --skip ast --skip syntax_text --skip tidy` — passes clean (3/6 lib tests)