### PR TITLE
fix: address Miri UB in Arc, ThinArc, green types, and cursor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.15"
+version = "0.15.16"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.16.1"
+version = "0.16.2"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.16"
+version = "0.16.0"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,22 +5,23 @@ authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
-edition = "2021"
-rust-version = "1.77.0"
+edition = "2024"
+rust-version = "1.85.0"
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [workspace]
 members = ["xtask"]
 
 [dependencies]
-rustc-hash = "1.0.1"
-hashbrown = { version = "0.14.3", features = [
-    "inline-more",
+rustc-hash = "2.1.1"
+hashbrown = { version = "0.15.2", features = [
+	"inline-more",
+	"raw-entry",
 ], default-features = false }
-text-size = "1.1.0"
-countme = "3.0.0"
+text-size = "1.1.1"
+countme = "3.0.1"
 
-serde = { version = "1.0.89", optional = true, default-features = false }
+serde = { version = "1.0.218", optional = true, default-features = false }
 
 [dev-dependencies]
 m_lexer = "0.0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"
 description = "Library for generic lossless syntax trees"
 edition = "2021"
-
+rust-version = "1.77.0"
 exclude = [".github/", "bors.toml", "rustfmt.toml"]
 
 [workspace]
@@ -18,7 +18,6 @@ hashbrown = { version = "0.14.3", features = [
     "inline-more",
 ], default-features = false }
 text-size = "1.1.0"
-memoffset = "0.9"
 countme = "3.0.0"
 
 serde = { version = "1.0.89", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Rowan
 
+[![docs.rs](https://docs.rs/rowan/badge.svg)](https://docs.rs/rowan/)
 [![Crates.io](https://img.shields.io/crates/v/rowan.svg)](https://crates.io/crates/rowan)
 [![Crates.io](https://img.shields.io/crates/d/rowan.svg)](https://crates.io/crates/rowan)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Rowan is a library for lossless syntax trees, inspired in part by
 Swift's [libsyntax](https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax).
 
-A conceptual overview is available in the [rust-analyzer repo](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md).
+A conceptual overview is available in the [rust-analyzer book](https://rust-analyzer.github.io/book/contributing/syntax.html).
 
 See `examples/s_expressions` for a tutorial, and [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/) for real-world usage.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Rowan is a library for lossless syntax trees, inspired in part by
 Swift's [libsyntax](https://github.com/apple/swift/tree/5e2c815edfd758f9b1309ce07bfc01c4bc20ec23/lib/Syntax).
 
-A conceptual overview is available in the [rust-analyzer book](https://rust-analyzer.github.io/book/contributing/syntax.html).
+A conceptual overview is available in the [rust-analyzer repo](https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md).
 
 See `examples/s_expressions` for a tutorial, and [rust-analyzer](https://github.com/rust-analyzer/rust-analyzer/) for real-world usage.
 

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -111,7 +111,7 @@ impl<I: Iterator<Item = (SyntaxKind, String)>> Parser<I> {
 }
 
 fn print(indent: usize, element: SyntaxElement) {
-    let kind: SyntaxKind = element.kind().into();
+    let kind: SyntaxKind = element.kind();
     print!("{:indent$}", "", indent = indent);
     match element {
         NodeOrToken::Node(node) => {

--- a/examples/math.rs
+++ b/examples/math.rs
@@ -32,6 +32,7 @@ enum SyntaxKind {
     OPERATION,
     ROOT,
 }
+
 use SyntaxKind::*;
 
 impl From<SyntaxKind> for rowan::SyntaxKind {

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -7,7 +7,7 @@
 //!
 //! It's suggested to read the conceptual overview of the design
 //! alongside this tutorial:
-//! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
+//! https://rust-analyzer.github.io/book/contributing/syntax.html
 
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.

--- a/examples/s_expressions.rs
+++ b/examples/s_expressions.rs
@@ -7,7 +7,7 @@
 //!
 //! It's suggested to read the conceptual overview of the design
 //! alongside this tutorial:
-//! https://rust-analyzer.github.io/book/contributing/syntax.html
+//! https://github.com/rust-analyzer/rust-analyzer/blob/master/docs/dev/syntax.md
 
 /// Let's start with defining all kinds of tokens and
 /// composite nodes.
@@ -194,8 +194,10 @@ fn parse(text: &str) -> Parse {
 /// has identity semantics.
 
 type SyntaxNode = rowan::SyntaxNode<Lang>;
+
 #[allow(unused)]
 type SyntaxToken = rowan::SyntaxToken<Lang>;
+
 #[allow(unused)]
 type SyntaxElement = rowan::NodeOrToken<SyntaxNode, SyntaxToken>;
 
@@ -255,11 +257,7 @@ macro_rules! ast_node {
         impl $ast {
             #[allow(unused)]
             fn cast(node: SyntaxNode) -> Option<Self> {
-                if node.kind() == $kind {
-                    Some(Self(node))
-                } else {
-                    None
-                }
+                if node.kind() == $kind { Some(Self(node)) } else { None }
             }
         }
     };

--- a/src/api.rs
+++ b/src/api.rs
@@ -101,9 +101,10 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
     }
+
     /// Returns a green tree, equal to the green tree this node
-    /// belongs two, except with this node substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this node substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, replacement: GreenNode) -> GreenNode {
         self.raw.replace_with(replacement)
     }
@@ -263,8 +264,8 @@ impl<L: Language> SyntaxNode<L> {
 
 impl<L: Language> SyntaxToken<L> {
     /// Returns a green tree, equal to the green tree this token
-    /// belongs two, except with this token substitute. The complexity
-    /// of operation is proportional to the depth of the tree
+    /// belongs to, except with this token substituted. The complexity
+    /// of the operation is proportional to the depth of the tree.
     pub fn replace_with(&self, new_token: GreenToken) -> GreenNode {
         self.raw.replace_with(new_token)
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -98,6 +98,9 @@ impl<L: Language> SyntaxNode<L> {
     pub fn new_root(green: GreenNode) -> SyntaxNode<L> {
         SyntaxNode::from(cursor::SyntaxNode::new_root(green))
     }
+    pub fn new_root_mut(green: GreenNode) -> SyntaxNode<L> {
+        SyntaxNode::from(cursor::SyntaxNode::new_root_mut(green))
+    }
     /// Returns a green tree, equal to the green tree this node
     /// belongs two, except with this node substitute. The complexity
     /// of operation is proportional to the depth of the tree

--- a/src/api.rs
+++ b/src/api.rs
@@ -247,6 +247,10 @@ impl<L: Language> SyntaxNode<L> {
         SyntaxNode::from(self.raw.clone_for_update())
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.raw.is_mutable()
+    }
+
     pub fn detach(&self) {
         self.raw.detach()
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,8 +1,8 @@
 use std::{borrow::Cow, fmt, iter, marker::PhantomData, ops::Range};
 
 use crate::{
-    cursor, green::GreenTokenData, Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken,
-    SyntaxKind, SyntaxText, TextRange, TextSize, TokenAtOffset, WalkEvent,
+    Direction, GreenNode, GreenNodeData, GreenToken, NodeOrToken, SyntaxKind, SyntaxText,
+    TextRange, TextSize, TokenAtOffset, WalkEvent, cursor, green::GreenTokenData,
 };
 
 pub trait Language: Sized + Copy + fmt::Debug + Eq + Ord + std::hash::Hash {
@@ -446,10 +446,7 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 
 impl<L: Language> SyntaxNodeChildren<L> {
     pub fn by_kind(self, matcher: impl Fn(L::Kind) -> bool) -> impl Iterator<Item = SyntaxNode<L>> {
-        self.raw
-            .by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind)))
-            .into_iter()
-            .map(SyntaxNode::from)
+        self.raw.by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind))).map(SyntaxNode::from)
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -472,6 +472,7 @@ impl<L: Language> SyntaxElementChildren<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder<L: Language> {
     raw: cursor::Preorder,
     _p: PhantomData<L>,
@@ -490,6 +491,7 @@ impl<L: Language> Iterator for Preorder<L> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens<L: Language> {
     raw: cursor::PreorderWithTokens,
     _p: PhantomData<L>,

--- a/src/api.rs
+++ b/src/api.rs
@@ -133,7 +133,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.parent().map(Self::from)
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -219,7 +219,7 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.last_token().map(SyntaxToken::from)
     }
 
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.siblings(direction).map(SyntaxNode::from)
     }
 
@@ -230,11 +230,11 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.siblings_with_tokens(direction).map(SyntaxElement::from)
     }
 
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.descendants().map(SyntaxNode::from)
     }
 
-    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> {
+    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw.descendants_with_tokens().map(NodeOrToken::from)
     }
 
@@ -337,12 +337,12 @@ impl<L: Language> SyntaxToken<L> {
 
     /// Iterator over all the ancestors of this token excluding itself.
     #[deprecated = "use `SyntaxToken::parent_ancestors` instead"]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.parent_ancestors()
     }
 
     /// Iterator over all the ancestors of this token excluding itself.
-    pub fn parent_ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn parent_ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
@@ -356,7 +356,7 @@ impl<L: Language> SyntaxToken<L> {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement<L>> {
+    ) -> impl Iterator<Item = SyntaxElement<L>> + use<L> {
         self.raw.siblings_with_tokens(direction).map(SyntaxElement::from)
     }
 
@@ -403,7 +403,7 @@ impl<L: Language> SyntaxElement<L> {
         }
     }
 
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode<L>> + use<L> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -214,7 +214,7 @@ impl<L: Language> SyntaxNode<L> {
     }
 
     /// Find a token in the subtree corresponding to this node, which covers the offset.
-    /// Precondition: offset must be withing node's range.
+    /// Precondition: offset must be within node's range.
     pub fn token_at_offset(&self, offset: TextSize) -> TokenAtOffset<SyntaxToken<L>> {
         self.raw.token_at_offset(offset).map(SyntaxToken::from)
     }
@@ -222,7 +222,7 @@ impl<L: Language> SyntaxNode<L> {
     /// Return the deepest node or token in the current subtree that fully
     /// contains the range. If the range is empty and is contained in two leaf
     /// nodes, either one can be returned. Precondition: range must be contained
-    /// withing the current node
+    /// within the current node
     pub fn covering_element(&self, range: TextRange) -> SyntaxElement<L> {
         NodeOrToken::from(self.raw.covering_element(range))
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -441,30 +441,11 @@ impl<L: Language> Iterator for SyntaxNodeChildren<L> {
 }
 
 impl<L: Language> SyntaxNodeChildren<L> {
-    pub fn by_kind<'a>(
-        self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxNodeChildrenByKind<'a, L> {
-        SyntaxNodeChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxNodeChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxNodeChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxNodeChildrenByKind<'a, L> {
-    type Item = SyntaxNode<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(SyntaxNode::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxNodeChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxNodeChildrenByKind").finish()
+    pub fn by_kind(self, matcher: impl Fn(L::Kind) -> bool) -> impl Iterator<Item = SyntaxNode<L>> {
+        self.raw
+            .by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind)))
+            .into_iter()
+            .map(SyntaxNode::from)
     }
 }
 
@@ -482,30 +463,11 @@ impl<L: Language> Iterator for SyntaxElementChildren<L> {
 }
 
 impl<L: Language> SyntaxElementChildren<L> {
-    pub fn by_kind<'a>(
+    pub fn by_kind(
         self,
-        matcher: &'a dyn Fn(SyntaxKind) -> bool,
-    ) -> SyntaxElementChildrenByKind<'a, L> {
-        SyntaxElementChildrenByKind { raw: self.raw.by_kind(matcher), _p: PhantomData }
-    }
-}
-
-#[derive(Clone)]
-pub struct SyntaxElementChildrenByKind<'a, L: Language> {
-    raw: cursor::SyntaxElementChildrenByKind<&'a dyn Fn(SyntaxKind) -> bool>,
-    _p: PhantomData<L>,
-}
-
-impl<'a, L: Language> Iterator for SyntaxElementChildrenByKind<'a, L> {
-    type Item = SyntaxElement<L>;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.raw.next().map(NodeOrToken::from)
-    }
-}
-
-impl<'a, L: Language> fmt::Debug for SyntaxElementChildrenByKind<'a, L> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SyntaxElementChildrenByKind").finish()
+        matcher: impl Fn(L::Kind) -> bool,
+    ) -> impl Iterator<Item = SyntaxElement<L>> {
+        self.raw.by_kind(move |raw_kind| matcher(L::kind_from_raw(raw_kind))).map(NodeOrToken::from)
     }
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -256,8 +256,12 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.detach()
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement<L>>) {
-        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from).collect::<Vec<_>>();
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement<L>>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
+        let to_insert = to_insert.into_iter().map(cursor::SyntaxElement::from);
         self.raw.splice_children(to_delete, to_insert)
     }
 }

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -83,7 +83,7 @@ impl<T: ?Sized> Arc<T> {
     /// allocation
     #[inline]
     pub(crate) fn ptr_eq(this: &Self, other: &Self) -> bool {
-        this.ptr() == other.ptr()
+        std::ptr::addr_eq(this.ptr(), other.ptr())
     }
 
     pub(crate) fn ptr(&self) -> *mut ArcInner<T> {

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, offset_of, ManuallyDrop},
+    mem::{self, ManuallyDrop, offset_of},
     ops::Deref,
     ptr,
     sync::atomic::{
@@ -55,14 +55,17 @@ impl<T> Arc<T> {
     pub(crate) unsafe fn from_raw(ptr: *const T) -> Self {
         // To find the corresponding pointer to the `ArcInner` we need
         // to subtract the offset of the `data` field from the pointer.
-        let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
-        Arc { p: ptr::NonNull::new_unchecked(ptr as *mut ArcInner<T>), phantom: PhantomData }
+        unsafe {
+            let ptr = (ptr as *const u8).sub(offset_of!(ArcInner<T>, data));
+            Arc { p: ptr::NonNull::new_unchecked(ptr as *mut ArcInner<T>), phantom: PhantomData }
+        }
     }
 }
 
 impl<T: ?Sized> Arc<T> {
     #[inline]
     fn inner(&self) -> &ArcInner<T> {
+        // SAFETY:
         // This unsafety is ok because while this arc is alive we're guaranteed
         // that the inner pointer is valid. Furthermore, we know that the
         // `ArcInner` structure itself is `Sync` because the inner data is
@@ -74,7 +77,9 @@ impl<T: ?Sized> Arc<T> {
     // Non-inlined part of `drop`. Just invokes the destructor.
     #[inline(never)]
     unsafe fn drop_slow(&mut self) {
-        let _ = Box::from_raw(self.ptr());
+        unsafe {
+            let _ = Box::from_raw(self.ptr());
+        }
     }
 
     /// Test pointer equality between the two Arcs, i.e. they must be the _same_
@@ -195,10 +200,6 @@ impl<T: ?Sized + PartialEq> PartialEq for Arc<T> {
     fn eq(&self, other: &Arc<T>) -> bool {
         Self::ptr_eq(self, other) || *(*self) == *(*other)
     }
-
-    fn ne(&self, other: &Arc<T>) -> bool {
-        !Self::ptr_eq(self, other) && *(*self) != *(*other)
-    }
 }
 
 impl<T: ?Sized + PartialOrd> PartialOrd for Arc<T> {
@@ -312,10 +313,7 @@ impl<H, T> ThinArc<H, T> {
         };
 
         // Expose the transient Arc to the callback, which may clone it if it wants.
-        let result = f(&transient);
-
-        // Forward the result.
-        result
+        f(&transient)
     }
 
     /// Creates a `ThinArc` for a HeaderSlice using the given header struct and

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,12 +257,10 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-        unsafe {
             let len = self.length;
             let fake_slice: *const [T] =
                 ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            &*(fake_slice as *const HeaderSlice<H, [T]>)
-        }
+            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -4,7 +4,7 @@ use std::{
     cmp::Ordering,
     hash::{Hash, Hasher},
     marker::PhantomData,
-    mem::{self, ManuallyDrop},
+    mem::{self, offset_of, ManuallyDrop},
     ops::Deref,
     ptr,
     sync::atomic::{
@@ -12,8 +12,6 @@ use std::{
         Ordering::{Acquire, Relaxed, Release},
     },
 };
-
-use memoffset::offset_of;
 
 /// A soft limit on the amount of references that may be made to an `Arc`.
 ///

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -257,10 +257,9 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
     type Target = HeaderSlice<H, [T]>;
 
     fn deref(&self) -> &Self::Target {
-            let len = self.length;
-            let fake_slice: *const [T] =
-                ptr::slice_from_raw_parts(self as *const _ as *const T, len);
-            unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
+        let len = self.length;
+        let fake_slice: *const [T] = ptr::slice_from_raw_parts(self as *const _ as *const T, len);
+        unsafe { &*(fake_slice as *const HeaderSlice<H, [T]>) }
     }
 }
 

--- a/src/arc.rs
+++ b/src/arc.rs
@@ -108,7 +108,8 @@ impl<T: ?Sized> Clone for Arc<T> {
         // another must already provide any required synchronization.
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
-        let old_size = self.inner().count.fetch_add(1, Relaxed);
+        let count_ptr = unsafe { ptr::addr_of!((*self.ptr()).count) };
+        let old_size = unsafe { (*count_ptr).fetch_add(1, Relaxed) };
 
         // However we need to guard against massive refcounts in case someone
         // is `mem::forget`ing Arcs. If we don't do this the count can overflow
@@ -155,16 +156,19 @@ impl<T: ?Sized> Arc<T> {
         // See the extensive discussion in [1] for why this needs to be Acquire.
         //
         // [1] https://github.com/servo/servo/issues/21186
-        self.inner().count.load(Acquire) == 1
+        let count_ptr = unsafe { ptr::addr_of!((*self.ptr()).count) };
+        unsafe { (*count_ptr).load(Acquire) == 1 }
     }
 }
 
 impl<T: ?Sized> Drop for Arc<T> {
     #[inline]
     fn drop(&mut self) {
-        // Because `fetch_sub` is already atomic, we do not need to synchronize
-        // with other threads unless we are going to delete the object.
-        if self.inner().count.fetch_sub(1, Release) != 1 {
+        // Access the refcount via raw pointer to avoid creating a reference
+        // to ArcInner<T> whose provenance may be limited when T is a thin
+        // type wrapping a dynamically-sized allocation.
+        let count_ptr = unsafe { ptr::addr_of!((*self.ptr()).count) };
+        if unsafe { (*count_ptr).fetch_sub(1, Release) } != 1 {
             return;
         }
 
@@ -188,7 +192,7 @@ impl<T: ?Sized> Drop for Arc<T> {
         //
         // [1]: (www.boost.org/doc/libs/1_55_0/doc/html/atomic/usage_examples.html)
         // [2]: https://github.com/rust-lang/rust/pull/41714
-        self.inner().count.load(Acquire);
+        unsafe { (*count_ptr).load(Acquire) };
 
         unsafe {
             self.drop_slow();
@@ -242,8 +246,8 @@ impl<T: ?Sized + Hash> Hash for Arc<T> {
 #[repr(C)]
 pub(crate) struct HeaderSlice<H, T: ?Sized> {
     pub(crate) header: H,
-    length: usize,
-    slice: T,
+    pub(crate) length: usize,
+    pub(crate) slice: T,
 }
 
 impl<H, T> HeaderSlice<H, [T]> {
@@ -279,7 +283,7 @@ impl<H, T> Deref for HeaderSlice<H, [T; 0]> {
 /// via `HeaderSlice`.
 #[repr(transparent)]
 pub(crate) struct ThinArc<H, T> {
-    ptr: ptr::NonNull<ArcInner<HeaderSlice<H, [T; 0]>>>,
+    pub(crate) ptr: ptr::NonNull<ArcInner<HeaderSlice<H, [T; 0]>>>,
     phantom: PhantomData<(H, T)>,
 }
 
@@ -287,7 +291,7 @@ unsafe impl<H: Sync + Send, T: Sync + Send> Send for ThinArc<H, T> {}
 unsafe impl<H: Sync + Send, T: Sync + Send> Sync for ThinArc<H, T> {}
 
 // Synthesize a fat pointer from a thin pointer.
-fn thin_to_thick<H, T>(
+pub(crate) fn thin_to_thick<H, T>(
     thin: *mut ArcInner<HeaderSlice<H, [T; 0]>>,
 ) -> *mut ArcInner<HeaderSlice<H, [T]>> {
     let len = unsafe { (*thin).data.length };
@@ -300,6 +304,7 @@ impl<H, T> ThinArc<H, T> {
     /// Temporarily converts |self| into a bonafide Arc and exposes it to the
     /// provided callback. The refcount is not modified.
     #[inline]
+    #[allow(dead_code)] // kept for downstream users; Clone/Drop now use raw pointers
     pub(crate) fn with_arc<F, U>(&self, f: F) -> U
     where
         F: FnOnce(&Arc<HeaderSlice<H, [T]>>) -> U,
@@ -402,14 +407,35 @@ impl<H, T> Deref for ThinArc<H, T> {
 impl<H, T> Clone for ThinArc<H, T> {
     #[inline]
     fn clone(&self) -> Self {
-        ThinArc::with_arc(self, |a| Arc::into_thin(a.clone()))
+        // Increment refcount directly via raw pointer, avoiding the
+        // with_arc → Arc::clone path that creates intermediate references.
+        let count_ptr = unsafe { ptr::addr_of!((*self.ptr.as_ptr()).count) };
+        let old_size = unsafe { (*count_ptr).fetch_add(1, Relaxed) };
+        if old_size > MAX_REFCOUNT {
+            std::process::abort();
+        }
+        ThinArc { ptr: self.ptr, phantom: PhantomData }
     }
 }
 
 impl<H, T> Drop for ThinArc<H, T> {
     #[inline]
     fn drop(&mut self) {
-        let _ = Arc::from_thin(ThinArc { ptr: self.ptr, phantom: PhantomData });
+        // Decrement refcount and deallocate directly via raw pointer,
+        // avoiding the from_thin → Arc::drop path which creates intermediate
+        // references that Miri flags for provenance issues.
+        let ptr = self.ptr.as_ptr();
+        let count_ptr = unsafe { ptr::addr_of!((*ptr).count) };
+        if unsafe { (*count_ptr).fetch_sub(1, Release) } != 1 {
+            return;
+        }
+        atomic::fence(Acquire);
+        unsafe {
+            let thick = thin_to_thick(ptr);
+            let layout = alloc::Layout::for_value(&*thick);
+            ptr::drop_in_place(&mut (*thick).data);
+            alloc::dealloc(ptr as *mut u8, layout);
+        }
     }
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -156,7 +156,7 @@ impl<N: AstNode> AstPtr<N> {
 
     /// Returns the underlying [`SyntaxNodePtr`].
     pub fn syntax_node_ptr(&self) -> SyntaxNodePtr<N::Language> {
-        self.raw.clone()
+        self.raw
     }
 
     /// Casts this to an [`AstPtr`] to the given node type if possible.
@@ -176,7 +176,7 @@ impl<N: AstNode> fmt::Debug for AstPtr<N> {
 
 impl<N: AstNode> Clone for AstPtr<N> {
     fn clone(&self) -> Self {
-        Self { raw: self.raw.clone() }
+        Self { raw: self.raw }
     }
 }
 

--- a/src/cow_mut.rs
+++ b/src/cow_mut.rs
@@ -9,7 +9,7 @@ impl<T> std::ops::Deref for CowMut<'_, T> {
     fn deref(&self) -> &T {
         match self {
             CowMut::Owned(it) => it,
-            CowMut::Borrowed(it) => *it,
+            CowMut::Borrowed(it) => it,
         }
     }
 }
@@ -18,7 +18,7 @@ impl<T> std::ops::DerefMut for CowMut<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         match self {
             CowMut::Owned(it) => it,
-            CowMut::Borrowed(it) => *it,
+            CowMut::Borrowed(it) => it,
         }
     }
 }

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -668,7 +668,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), SyntaxNode::parent)
     }
 
@@ -831,7 +831,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> {
+    pub fn siblings(&self, direction: Direction) -> impl Iterator<Item = SyntaxNode> + use<> {
         iter::successors(Some(self.clone()), move |node| match direction {
             Direction::Next => node.next_sibling(),
             Direction::Prev => node.prev_sibling(),
@@ -842,7 +842,7 @@ impl SyntaxNode {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let me: SyntaxElement = self.clone().into();
         iter::successors(Some(me), move |el| match direction {
             Direction::Next => el.next_sibling_or_token(),
@@ -851,7 +851,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn descendants(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         self.preorder().filter_map(|event| match event {
             WalkEvent::Enter(node) => Some(node),
             WalkEvent::Leave(_) => None,
@@ -859,7 +859,7 @@ impl SyntaxNode {
     }
 
     #[inline]
-    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> {
+    pub fn descendants_with_tokens(&self) -> impl Iterator<Item = SyntaxElement> + use<> {
         self.preorder_with_tokens().filter_map(|event| match event {
             WalkEvent::Enter(it) => Some(it),
             WalkEvent::Leave(_) => None,
@@ -1054,7 +1054,7 @@ impl SyntaxToken {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         std::iter::successors(self.parent(), SyntaxNode::parent)
     }
 
@@ -1077,7 +1077,7 @@ impl SyntaxToken {
     pub fn siblings_with_tokens(
         &self,
         direction: Direction,
-    ) -> impl Iterator<Item = SyntaxElement> {
+    ) -> impl Iterator<Item = SyntaxElement> + use<> {
         let me: SyntaxElement = self.clone().into();
         iter::successors(Some(me), move |el| match direction {
             Direction::Next => el.next_sibling_or_token(),
@@ -1156,7 +1156,7 @@ impl SyntaxElement {
     }
 
     #[inline]
-    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> {
+    pub fn ancestors(&self) -> impl Iterator<Item = SyntaxNode> + use<> {
         let first = match self {
             NodeOrToken::Node(it) => Some(it.clone()),
             NodeOrToken::Token(it) => it.parent(),

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -1474,6 +1474,7 @@ impl<F: Fn(SyntaxKind) -> bool> Iterator for SyntaxElementChildrenByKind<F> {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct Preorder {
     start: SyntaxNode,
     next: Option<WalkEvent<SyntaxNode>>,
@@ -1529,6 +1530,7 @@ impl Iterator for Preorder {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct PreorderWithTokens {
     start: SyntaxElement,
     next: Option<WalkEvent<SyntaxElement>>,

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -408,7 +408,7 @@ impl NodeData {
         let rev_siblings = self.green_siblings().enumerate().rev();
         let index = rev_siblings.len().checked_sub(self.index() as usize)?;
 
-        rev_siblings.skip(index + 1).find_map(|(index, child)| {
+        rev_siblings.skip(index).find_map(|(index, child)| {
             child.as_ref().into_node().and_then(|green| {
                 let parent = self.parent_node()?;
                 let offset = parent.offset() + child.rel_offset();

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -544,6 +544,10 @@ impl SyntaxNode {
         SyntaxNode { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
     }
 
+    pub fn is_mutable(&self) -> bool {
+        self.data().mutable
+    }
+
     pub fn clone_for_update(&self) -> SyntaxNode {
         assert!(!self.data().mutable);
         match self.parent() {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -806,7 +806,11 @@ impl SyntaxNode {
         })
     }
 
-    pub fn splice_children(&self, to_delete: Range<usize>, to_insert: Vec<SyntaxElement>) {
+    pub fn splice_children<I: IntoIterator<Item = SyntaxElement>>(
+        &self,
+        to_delete: Range<usize>,
+        to_insert: I,
+    ) {
         assert!(self.data().mutable, "immutable tree: {}", self);
         for (i, child) in self.children_with_tokens().enumerate() {
             if to_delete.contains(&i) {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -790,6 +790,7 @@ impl SyntaxNode {
                 Some(SyntaxNode { ptr })
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })
@@ -1234,6 +1235,7 @@ impl SyntaxElement {
                 }
             })
             .or_else(|| {
+                data.dec_rc();
                 unsafe { free(ptr) };
                 None
             })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -478,7 +478,7 @@ impl NodeData {
 
         match self.green() {
             NodeOrToken::Node(green) => {
-                // Child is root, so it ownes the green node. Steal it!
+                // Child is root, so it owns the green node. Steal it!
                 let child_green = match &child.green {
                     Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.get()).into() },
                     Green::Token { ptr } => unsafe { GreenToken::from_raw(*ptr).into() },

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -121,6 +121,9 @@ struct NodeData {
     mutable: bool,
     /// Absolute offset for immutable nodes, unused for mutable nodes.
     offset: TextSize,
+    /// Raw pointer to self with original allocation provenance.
+    /// Used for deallocation — survives reference freezing under tree borrows.
+    self_alloc: *mut NodeData,
     // The following links only have meaning when `mutable` is true.
     first: Cell<*const NodeData>,
     /// Invariant: never null if mutable.
@@ -144,44 +147,64 @@ unsafe impl sll::Elem for NodeData {
 pub type SyntaxElement = NodeOrToken<SyntaxNode, SyntaxToken>;
 
 pub struct SyntaxNode {
-    ptr: ptr::NonNull<NodeData>,
+    /// Wrapped in UnsafeCell so that reading the pointer through &self
+    /// does not freeze provenance under tree/stacked borrows. This allows
+    /// the pointer to retain write/dealloc permission through the
+    /// lifecycle of the SyntaxNode.
+    ptr: std::cell::UnsafeCell<ptr::NonNull<NodeData>>,
+}
+
+impl SyntaxNode {
+    #[inline]
+    fn ptr(&self) -> ptr::NonNull<NodeData> {
+        unsafe { *self.ptr.get() }
+    }
 }
 
 impl Clone for SyntaxNode {
     #[inline]
     fn clone(&self) -> Self {
         self.data().inc_rc();
-        SyntaxNode { ptr: self.ptr }
+        SyntaxNode { ptr: std::cell::UnsafeCell::new(self.ptr()) }
     }
 }
 
 impl Drop for SyntaxNode {
     #[inline]
     fn drop(&mut self) {
-        if self.data().dec_rc() {
-            unsafe { free(self.ptr) }
+        let ptr = self.ptr();
+        if unsafe { NodeData::dec_rc_raw(ptr) } {
+            unsafe { free(ptr) }
         }
     }
 }
 
 #[derive(Debug)]
 pub struct SyntaxToken {
-    ptr: ptr::NonNull<NodeData>,
+    ptr: std::cell::UnsafeCell<ptr::NonNull<NodeData>>,
+}
+
+impl SyntaxToken {
+    #[inline]
+    fn ptr(&self) -> ptr::NonNull<NodeData> {
+        unsafe { *self.ptr.get() }
+    }
 }
 
 impl Clone for SyntaxToken {
     #[inline]
     fn clone(&self) -> Self {
         self.data().inc_rc();
-        SyntaxToken { ptr: self.ptr }
+        SyntaxToken { ptr: std::cell::UnsafeCell::new(self.ptr()) }
     }
 }
 
 impl Drop for SyntaxToken {
     #[inline]
     fn drop(&mut self) {
-        if self.data().dec_rc() {
-            unsafe { free(self.ptr) }
+        let ptr = self.ptr();
+        if unsafe { NodeData::dec_rc_raw(ptr) } {
+            unsafe { free(ptr) }
         }
     }
 }
@@ -190,16 +213,18 @@ impl Drop for SyntaxToken {
 unsafe fn free(mut data: ptr::NonNull<NodeData>) {
     unsafe {
         loop {
-            debug_assert_eq!(data.as_ref().rc.get(), 0);
-            debug_assert!(data.as_ref().first.get().is_null());
-            let node = Box::from_raw(data.as_ptr());
+            // Use self_alloc which retains original Box::into_raw provenance,
+            // unaffected by any &NodeData references created during the node's lifetime.
+            let alloc_ptr = (*data.as_ptr()).self_alloc;
+            let node = Box::from_raw(alloc_ptr);
+            debug_assert_eq!(node.rc.get(), 0);
+            debug_assert!(node.first.get().is_null());
             match node.parent.take() {
                 Some(parent) => {
-                    debug_assert!(parent.as_ref().rc.get() > 0);
                     if node.mutable {
-                        sll::unlink(&parent.as_ref().first, &*node)
+                        sll::unlink(&(*parent.as_ptr()).first, &*node)
                     }
-                    if parent.as_ref().dec_rc() {
+                    if NodeData::dec_rc_raw(parent) {
                         data = parent;
                     } else {
                         break;
@@ -208,7 +233,8 @@ unsafe fn free(mut data: ptr::NonNull<NodeData>) {
                 None => {
                     match &node.green {
                         Green::Node { ptr } => {
-                            let _ = GreenNode::from_raw(ptr.get());
+                            let p = ptr.as_ptr().read();
+                            let _ = GreenNode::from_raw(p);
                         }
                         Green::Token { ptr } => {
                             let _ = GreenToken::from_raw(*ptr);
@@ -234,12 +260,13 @@ impl NodeData {
         let res = NodeData {
             _c: Count::new(),
             rc: Cell::new(1),
-            parent: Cell::new(parent.as_ref().map(|it| it.ptr)),
+            parent: Cell::new(parent.as_ref().map(|it| it.ptr())),
             index: Cell::new(index),
             green,
 
             mutable,
             offset,
+            self_alloc: ptr::null_mut(),
             first: Cell::new(ptr::null()),
             next: Cell::new(ptr::null()),
             prev: Cell::new(ptr::null()),
@@ -272,12 +299,15 @@ impl NodeData {
                     }
                     it => {
                         let res = Box::into_raw(Box::new(res));
+                        (*res).self_alloc = res;
                         it.add_to_sll(res);
                         return ptr::NonNull::new_unchecked(res);
                     }
                 }
             }
-            ptr::NonNull::new_unchecked(Box::into_raw(Box::new(res)))
+            let raw = Box::into_raw(Box::new(res));
+            (*raw).self_alloc = raw;
+            ptr::NonNull::new_unchecked(raw)
         }
     }
 
@@ -297,10 +327,27 @@ impl NodeData {
         rc == 0
     }
 
+    /// Decrement refcount via raw pointer only — no references created.
+    /// This preserves deallocation permission under tree/stacked borrows.
+    #[inline]
+    unsafe fn dec_rc_raw(ptr: ptr::NonNull<NodeData>) -> bool {
+        // Access the Cell<u32>'s inner value via raw pointer.
+        // Cell::get()/set() create &Cell<u32> references which under tree
+        // borrows freeze the parent allocation's borrow tag.
+        unsafe {
+            let rc_cell_ptr = ptr::addr_of!((*ptr.as_ptr()).rc);
+            // Cell<u32> wraps UnsafeCell<u32> — its memory layout is just u32.
+            let rc_val_ptr = rc_cell_ptr as *mut u32;
+            let rc = rc_val_ptr.read() - 1;
+            rc_val_ptr.write(rc);
+            rc == 0
+        }
+    }
+
     #[inline]
     fn key(&self) -> (ptr::NonNull<()>, TextSize) {
         let ptr = match &self.green {
-            Green::Node { ptr } => ptr.get().cast(),
+            Green::Node { ptr } => unsafe { ptr.as_ptr().read() }.cast(),
             Green::Token { ptr } => ptr.cast(),
         };
         (ptr, self.offset())
@@ -311,7 +358,7 @@ impl NodeData {
         let parent = self.parent()?;
         debug_assert!(matches!(parent.green, Green::Node { .. }));
         parent.inc_rc();
-        Some(SyntaxNode { ptr: ptr::NonNull::from(parent) })
+        Some(SyntaxNode { ptr: std::cell::UnsafeCell::new(ptr::NonNull::from(parent)) })
     }
 
     #[inline]
@@ -322,14 +369,14 @@ impl NodeData {
     #[inline]
     fn green(&self) -> GreenElementRef<'_> {
         match &self.green {
-            Green::Node { ptr } => GreenElementRef::Node(unsafe { &*ptr.get().as_ptr() }),
+            Green::Node { ptr } => GreenElementRef::Node(unsafe { &*ptr.as_ptr().read().as_ptr() }),
             Green::Token { ptr } => GreenElementRef::Token(unsafe { ptr.as_ref() }),
         }
     }
     #[inline]
     fn green_siblings(&self) -> slice::Iter<GreenChild> {
         match &self.parent().map(|it| &it.green) {
-            Some(Green::Node { ptr }) => unsafe { &*ptr.get().as_ptr() }.children().raw,
+            Some(Green::Node { ptr }) => unsafe { &*ptr.as_ptr().read().as_ptr() }.children().raw,
             Some(Green::Token { .. }) => {
                 debug_assert!(false);
                 [].iter()
@@ -511,7 +558,7 @@ impl NodeData {
             NodeOrToken::Node(green) => {
                 // Child is root, so it owns the green node. Steal it!
                 let child_green = match &child.green {
-                    Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.get()).into() },
+                    Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.as_ptr().read()).into() },
                     Green::Token { ptr } => unsafe { GreenToken::from_raw(*ptr).into() },
                 };
 
@@ -553,13 +600,13 @@ impl SyntaxNode {
     pub fn new_root(green: GreenNode) -> SyntaxNode {
         let green = GreenNode::into_raw(green);
         let green = Green::Node { ptr: Cell::new(green) };
-        SyntaxNode { ptr: NodeData::new(None, 0, 0.into(), green, false) }
+        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, false)) }
     }
 
     pub fn new_root_mut(green: GreenNode) -> SyntaxNode {
         let green = GreenNode::into_raw(green);
         let green = Green::Node { ptr: Cell::new(green) };
-        SyntaxNode { ptr: NodeData::new(None, 0, 0.into(), green, true) }
+        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, true)) }
     }
 
     fn new_child(
@@ -570,7 +617,7 @@ impl SyntaxNode {
     ) -> SyntaxNode {
         let mutable = parent.data().mutable;
         let green = Green::Node { ptr: Cell::new(green.into()) };
-        SyntaxNode { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
+        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(Some(parent), index, offset, green, mutable)) }
     }
 
     pub fn is_mutable(&self) -> bool {
@@ -594,7 +641,7 @@ impl SyntaxNode {
 
     #[inline]
     fn data(&self) -> &NodeData {
-        unsafe { self.ptr.as_ref() }
+        unsafe { self.ptr().as_ref() }
     }
 
     #[inline]
@@ -605,8 +652,7 @@ impl SyntaxNode {
     #[inline]
     fn take_ptr(self) -> ptr::NonNull<NodeData> {
         assert!(self.can_take_ptr());
-        let ret = self.ptr;
-        // don't change the refcount when self gets dropped
+        let ret = self.ptr();
         std::mem::forget(self);
         ret
     }
@@ -784,7 +830,7 @@ impl SyntaxNode {
                 data.index.set(index);
                 data.offset = parent_offset + rel_offset;
                 data.green = Green::Node { ptr: Cell::new(green.into()) };
-                SyntaxNode { ptr }
+                SyntaxNode { ptr: std::cell::UnsafeCell::new(ptr) }
             })
             .or_else(|| {
                 data.dec_rc();
@@ -982,12 +1028,12 @@ impl SyntaxToken {
     ) -> SyntaxToken {
         let mutable = parent.data().mutable;
         let green = Green::Token { ptr: green.into() };
-        SyntaxToken { ptr: NodeData::new(Some(parent), index, offset, green, mutable) }
+        SyntaxToken { ptr: std::cell::UnsafeCell::new(NodeData::new(Some(parent), index, offset, green, mutable)) }
     }
 
     #[inline]
     fn data(&self) -> &NodeData {
-        unsafe { self.ptr.as_ref() }
+        unsafe { self.ptr().as_ref() }
     }
 
     #[inline]
@@ -998,8 +1044,7 @@ impl SyntaxToken {
     #[inline]
     fn take_ptr(self) -> ptr::NonNull<NodeData> {
         assert!(self.can_take_ptr());
-        let ret = self.ptr;
-        // don't change the refcount when self gets dropped
+        let ret = self.ptr();
         std::mem::forget(self);
         ret
     }
@@ -1223,11 +1268,11 @@ impl SyntaxElement {
                 match green.as_ref() {
                     NodeOrToken::Node(node) => {
                         data.green = Green::Node { ptr: Cell::new(node.into()) };
-                        Some(SyntaxElement::Node(SyntaxNode { ptr }))
+                        Some(SyntaxElement::Node(SyntaxNode { ptr: std::cell::UnsafeCell::new(ptr) }))
                     }
                     NodeOrToken::Token(token) => {
                         data.green = Green::Token { ptr: token.into() };
-                        Some(SyntaxElement::Token(SyntaxToken { ptr }))
+                        Some(SyntaxElement::Token(SyntaxToken { ptr: std::cell::UnsafeCell::new(ptr) }))
                     }
                 }
             })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -374,7 +374,7 @@ impl NodeData {
         }
     }
     #[inline]
-    fn green_siblings(&self) -> slice::Iter<GreenChild> {
+    fn green_siblings(&self) -> slice::Iter<'_, GreenChild> {
         match &self.parent().map(|it| &it.green) {
             Some(Green::Node { ptr }) => unsafe { &*ptr.as_ptr().read().as_ptr() }.children().raw,
             Some(Green::Token { .. }) => {
@@ -558,7 +558,9 @@ impl NodeData {
             NodeOrToken::Node(green) => {
                 // Child is root, so it owns the green node. Steal it!
                 let child_green = match &child.green {
-                    Green::Node { ptr } => unsafe { GreenNode::from_raw(ptr.as_ptr().read()).into() },
+                    Green::Node { ptr } => unsafe {
+                        GreenNode::from_raw(ptr.as_ptr().read()).into()
+                    },
                     Green::Token { ptr } => unsafe { GreenToken::from_raw(*ptr).into() },
                 };
 
@@ -600,13 +602,17 @@ impl SyntaxNode {
     pub fn new_root(green: GreenNode) -> SyntaxNode {
         let green = GreenNode::into_raw(green);
         let green = Green::Node { ptr: Cell::new(green) };
-        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, false)) }
+        SyntaxNode {
+            ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, false)),
+        }
     }
 
     pub fn new_root_mut(green: GreenNode) -> SyntaxNode {
         let green = GreenNode::into_raw(green);
         let green = Green::Node { ptr: Cell::new(green) };
-        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, true)) }
+        SyntaxNode {
+            ptr: std::cell::UnsafeCell::new(NodeData::new(None, 0, 0.into(), green, true)),
+        }
     }
 
     fn new_child(
@@ -617,7 +623,15 @@ impl SyntaxNode {
     ) -> SyntaxNode {
         let mutable = parent.data().mutable;
         let green = Green::Node { ptr: Cell::new(green.into()) };
-        SyntaxNode { ptr: std::cell::UnsafeCell::new(NodeData::new(Some(parent), index, offset, green, mutable)) }
+        SyntaxNode {
+            ptr: std::cell::UnsafeCell::new(NodeData::new(
+                Some(parent),
+                index,
+                offset,
+                green,
+                mutable,
+            )),
+        }
     }
 
     pub fn is_mutable(&self) -> bool {
@@ -1028,7 +1042,15 @@ impl SyntaxToken {
     ) -> SyntaxToken {
         let mutable = parent.data().mutable;
         let green = Green::Token { ptr: green.into() };
-        SyntaxToken { ptr: std::cell::UnsafeCell::new(NodeData::new(Some(parent), index, offset, green, mutable)) }
+        SyntaxToken {
+            ptr: std::cell::UnsafeCell::new(NodeData::new(
+                Some(parent),
+                index,
+                offset,
+                green,
+                mutable,
+            )),
+        }
     }
 
     #[inline]
@@ -1268,11 +1290,15 @@ impl SyntaxElement {
                 match green.as_ref() {
                     NodeOrToken::Node(node) => {
                         data.green = Green::Node { ptr: Cell::new(node.into()) };
-                        Some(SyntaxElement::Node(SyntaxNode { ptr: std::cell::UnsafeCell::new(ptr) }))
+                        Some(SyntaxElement::Node(SyntaxNode {
+                            ptr: std::cell::UnsafeCell::new(ptr),
+                        }))
                     }
                     NodeOrToken::Token(token) => {
                         data.green = Green::Token { ptr: token.into() };
-                        Some(SyntaxElement::Token(SyntaxToken { ptr: std::cell::UnsafeCell::new(ptr) }))
+                        Some(SyntaxElement::Token(SyntaxToken {
+                            ptr: std::cell::UnsafeCell::new(ptr),
+                        }))
                     }
                 }
             })

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -256,11 +256,24 @@ impl NodeData {
         green: Green,
         mutable: bool,
     ) -> ptr::NonNull<NodeData> {
+        // Extract parent's self_alloc by consuming the Option temporarily.
+        // We take() the value, read self_alloc through UnsafeCell (no &SyntaxNode),
+        // then put it back. This avoids creating &SyntaxNode which would freeze provenance.
+        let (parent, parent_alloc) = match parent {
+            Some(p) => {
+                let alloc = unsafe {
+                    let node_data_ptr = (*p.ptr.get()).as_ptr();
+                    ptr::NonNull::new_unchecked((*node_data_ptr).self_alloc)
+                };
+                (Some(p), Some(alloc))
+            }
+            None => (None, None),
+        };
         let parent = ManuallyDrop::new(parent);
         let res = NodeData {
             _c: Count::new(),
             rc: Cell::new(1),
-            parent: Cell::new(parent.as_ref().map(|it| it.ptr())),
+            parent: Cell::new(parent_alloc),
             index: Cell::new(index),
             green,
 

--- a/src/green/builder.rs
+++ b/src/green/builder.rs
@@ -1,9 +1,9 @@
 use std::num::NonZeroUsize;
 
 use crate::{
-    cow_mut::CowMut,
-    green::{node_cache::NodeCache, GreenElement, GreenNode, SyntaxKind},
     NodeOrToken,
+    cow_mut::CowMut,
+    green::{GreenElement, GreenNode, SyntaxKind, node_cache::NodeCache},
 };
 
 /// A checkpoint for maybe wrapping a node. See `GreenNodeBuilder::checkpoint` for details.

--- a/src/green/element.rs
+++ b/src/green/element.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
 use crate::{
-    green::{GreenNode, GreenToken, SyntaxKind},
     GreenNodeData, NodeOrToken, TextSize,
+    green::{GreenNode, GreenToken, SyntaxKind},
 };
 
 use super::GreenTokenData;

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -12,7 +12,6 @@ use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::{GreenElement, GreenElementRef, SyntaxKind},
-    utility_types::static_assert,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -28,8 +27,6 @@ pub(crate) enum GreenChild {
     Node { rel_offset: TextSize, node: GreenNode },
     Token { rel_offset: TextSize, token: GreenToken },
 }
-#[cfg(target_pointer_width = "64")]
-static_assert!(mem::size_of::<GreenChild>() == mem::size_of::<usize>() * 2);
 
 type Repr = HeaderSlice<GreenNodeHead, [GreenChild]>;
 type ReprThin = HeaderSlice<GreenNodeHead, [GreenChild; 0]>;
@@ -356,3 +353,16 @@ impl DoubleEndedIterator for Children<'_> {
 }
 
 impl FusedIterator for Children<'_> {}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    #[cfg(target_pointer_width = "64")]
+    fn check_green_child_size() {
+        use super::GreenChild;
+        use std::mem;
+
+        assert_eq!(mem::size_of::<GreenChild>(), mem::size_of::<usize>() * 2);
+    }
+}

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -9,10 +9,10 @@ use std::{
 use countme::Count;
 
 use crate::{
+    GreenToken, NodeOrToken, TextRange, TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::{GreenElement, GreenElementRef, SyntaxKind},
     utility_types::static_assert,
-    GreenToken, NodeOrToken, TextRange, TextSize,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -66,7 +66,7 @@ impl ToOwned for GreenNodeData {
 impl Borrow<GreenNodeData> for GreenNode {
     #[inline]
     fn borrow(&self) -> &GreenNodeData {
-        &*self
+        self
     }
 }
 
@@ -89,14 +89,14 @@ impl fmt::Debug for GreenNodeData {
 
 impl fmt::Debug for GreenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenNodeData = &*self;
+        let data: &GreenNodeData = self;
         fmt::Debug::fmt(data, f)
     }
 }
 
 impl fmt::Display for GreenNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenNodeData = &*self;
+        let data: &GreenNodeData = self;
         fmt::Display::fmt(data, f)
     }
 }
@@ -159,11 +159,7 @@ impl GreenNodeData {
     pub fn replace_child(&self, index: usize, new_child: GreenElement) -> GreenNode {
         let mut replacement = Some(new_child);
         let children = self.children().enumerate().map(|(i, child)| {
-            if i == index {
-                replacement.take().unwrap()
-            } else {
-                child.to_owned()
-            }
+            if i == index { replacement.take().unwrap() } else { child.to_owned() }
         });
         GreenNode::new(self.kind(), children)
     }
@@ -238,15 +234,17 @@ impl GreenNode {
     #[inline]
     pub(crate) fn into_raw(this: GreenNode) -> ptr::NonNull<GreenNodeData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenNodeData = &*green;
-        ptr::NonNull::from(&*green)
+        let green: &GreenNodeData = &green;
+        ptr::NonNull::from(green)
     }
 
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenNodeData>) -> GreenNode {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, GreenChild>>(arc);
-        GreenNode { ptr: arc }
+        unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, GreenChild>>(arc);
+            GreenNode { ptr: arc }
+        }
     }
 }
 
@@ -321,19 +319,19 @@ impl<'a> Iterator for Children<'a> {
     }
 
     #[inline]
-    fn fold<Acc, Fold>(mut self, init: Acc, mut f: Fold) -> Acc
+    fn fold<Acc, Fold>(self, init: Acc, mut f: Fold) -> Acc
     where
         Fold: FnMut(Acc, Self::Item) -> Acc,
     {
         let mut accum = init;
-        while let Some(x) = self.next() {
+        for x in self {
             accum = f(accum, x);
         }
         accum
     }
 }
 
-impl<'a> DoubleEndedIterator for Children<'a> {
+impl DoubleEndedIterator for Children<'_> {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
         self.raw.next_back().map(GreenChild::as_ref)

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -23,6 +23,7 @@ pub(super) struct GreenNodeHead {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[repr(u8)]
 pub(crate) enum GreenChild {
     Node { rel_offset: TextSize, node: GreenNode },
     Token { rel_offset: TextSize, token: GreenToken },

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,11 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-        unsafe {
-            let green = GreenNode::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenNode::clone(&green)
-        }
     }
 }
 
@@ -194,8 +192,8 @@ impl ops::Deref for GreenNode {
 
     #[inline]
     fn deref(&self) -> &GreenNodeData {
+        let repr: &Repr = &self.ptr;
         unsafe {
-            let repr: &Repr = &self.ptr;
             let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
             mem::transmute::<&ReprThin, &GreenNodeData>(repr)
         }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -56,9 +56,9 @@ impl ToOwned for GreenNodeData {
 
     #[inline]
     fn to_owned(&self) -> GreenNode {
-            let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenNode::clone(&green)
+        let green = unsafe { GreenNode::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenNode::clone(&green)
     }
 }
 

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -10,7 +10,7 @@ use countme::Count;
 
 use crate::{
     GreenToken, NodeOrToken, TextRange, TextSize,
-    arc::{Arc, HeaderSlice, ThinArc},
+    arc::{Arc, HeaderSlice, ThinArc, thin_to_thick},
     green::{GreenElement, GreenElementRef, SyntaxKind},
 };
 
@@ -32,7 +32,7 @@ type Repr = HeaderSlice<GreenNodeHead, [GreenChild]>;
 type ReprThin = HeaderSlice<GreenNodeHead, [GreenChild; 0]>;
 #[repr(transparent)]
 pub struct GreenNodeData {
-    data: ReprThin,
+    data: Repr, // unsized — provenance covers the full slice
 }
 
 impl PartialEq for GreenNodeData {
@@ -186,11 +186,11 @@ impl ops::Deref for GreenNode {
 
     #[inline]
     fn deref(&self) -> &GreenNodeData {
+        // SAFETY: GreenNodeData is #[repr(transparent)] over Repr (fat HeaderSlice).
+        // ThinArc::deref() returns &HeaderSlice<H, [T]> with full allocation provenance
+        // via thin_to_thick(). We transmute to &GreenNodeData which has the same layout.
         let repr: &Repr = &self.ptr;
-        unsafe {
-            let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
-            mem::transmute::<&ReprThin, &GreenNodeData>(repr)
-        }
+        unsafe { mem::transmute::<&Repr, &GreenNodeData>(repr) }
     }
 }
 
@@ -231,14 +231,22 @@ impl GreenNode {
     #[inline]
     pub(crate) fn into_raw(this: GreenNode) -> ptr::NonNull<GreenNodeData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenNodeData = &green;
-        ptr::NonNull::from(green)
+        // Extract the raw pointer directly from ThinArc to preserve full
+        // allocation provenance. Going through Deref → &GreenNodeData would
+        // create a reference whose provenance is invalidated when the
+        // ManuallyDrop wrapper goes out of scope.
+        let thin_ptr = green.ptr.ptr.as_ptr();
+        let thick = thin_to_thick(thin_ptr);
+        unsafe { ptr::NonNull::new_unchecked(ptr::addr_of!((*thick).data) as *mut Repr as *mut GreenNodeData) }
     }
 
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenNodeData>) -> GreenNode {
         unsafe {
-            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            // Cast the fat pointer to thin: just reinterpret the data pointer
+            // (dropping the length metadata, which is stored in the HeaderSlice).
+            let thin_ptr = ptr.as_ptr() as *const Repr as *const ReprThin;
+            let arc = Arc::from_raw(thin_ptr);
             let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenNodeHead, GreenChild>>(arc);
             GreenNode { ptr: arc }
         }

--- a/src/green/node.rs
+++ b/src/green/node.rs
@@ -237,7 +237,11 @@ impl GreenNode {
         // ManuallyDrop wrapper goes out of scope.
         let thin_ptr = green.ptr.ptr.as_ptr();
         let thick = thin_to_thick(thin_ptr);
-        unsafe { ptr::NonNull::new_unchecked(ptr::addr_of!((*thick).data) as *mut Repr as *mut GreenNodeData) }
+        unsafe {
+            ptr::NonNull::new_unchecked(
+                ptr::addr_of!((*thick).data) as *mut Repr as *mut GreenNodeData
+            )
+        }
     }
 
     #[inline]
@@ -255,7 +259,7 @@ impl GreenNode {
 
 impl GreenChild {
     #[inline]
-    pub(crate) fn as_ref(&self) -> GreenElementRef {
+    pub(crate) fn as_ref(&self) -> GreenElementRef<'_> {
         match self {
             GreenChild::Node { node, .. } => NodeOrToken::Node(node),
             GreenChild::Token { token, .. } => NodeOrToken::Token(token),

--- a/src/green/node_cache.rs
+++ b/src/green/node_cache.rs
@@ -3,8 +3,8 @@ use rustc_hash::FxHasher;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 
 use crate::{
-    green::GreenElementRef, GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken,
-    SyntaxKind,
+    GreenNode, GreenNodeData, GreenToken, GreenTokenData, NodeOrToken, SyntaxKind,
+    green::GreenElementRef,
 };
 
 use super::element::GreenElement;

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,9 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
-            let green = ManuallyDrop::new(green);
-            GreenToken::clone(&green)
+        let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
+        let green = ManuallyDrop::new(green);
+        GreenToken::clone(&green)
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -44,11 +44,9 @@ impl ToOwned for GreenTokenData {
 
     #[inline]
     fn to_owned(&self) -> GreenToken {
-        unsafe {
-            let green = GreenToken::from_raw(ptr::NonNull::from(self));
+            let green = unsafe { GreenToken::from_raw(ptr::NonNull::from(self)) };
             let green = ManuallyDrop::new(green);
             GreenToken::clone(&green)
-        }
     }
 }
 

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -8,9 +8,9 @@ use std::{
 use countme::Count;
 
 use crate::{
+    TextSize,
     arc::{Arc, HeaderSlice, ThinArc},
     green::SyntaxKind,
-    TextSize,
 };
 
 #[derive(PartialEq, Eq, Hash)]
@@ -53,7 +53,7 @@ impl ToOwned for GreenTokenData {
 impl Borrow<GreenTokenData> for GreenToken {
     #[inline]
     fn borrow(&self) -> &GreenTokenData {
-        &*self
+        self
     }
 }
 
@@ -68,14 +68,14 @@ impl fmt::Debug for GreenTokenData {
 
 impl fmt::Debug for GreenToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenTokenData = &*self;
+        let data: &GreenTokenData = self;
         fmt::Debug::fmt(data, f)
     }
 }
 
 impl fmt::Display for GreenToken {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let data: &GreenTokenData = &*self;
+        let data: &GreenTokenData = self;
         fmt::Display::fmt(data, f)
     }
 }
@@ -117,14 +117,25 @@ impl GreenToken {
     #[inline]
     pub(crate) fn into_raw(this: GreenToken) -> ptr::NonNull<GreenTokenData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenTokenData = &*green;
-        ptr::NonNull::from(&*green)
+        let green: &GreenTokenData = &green;
+        ptr::NonNull::from(green)
     }
 
+    /// # Safety
+    ///
+    /// This function uses `unsafe` code to create an `Arc` from a raw pointer and then transmutes it into a `ThinArc`.
+    ///
+    /// - The raw pointer must be valid and correctly aligned for the type `ReprThin`.
+    /// - The lifetime of the raw pointer must outlive the lifetime of the `Arc` created from it.
+    /// - The transmute operation must be safe, meaning that the memory layout of `Arc<ReprThin>` must be compatible with `ThinArc<GreenTokenHead, u8>`.
+    ///
+    /// Failure to uphold these invariants can lead to undefined behavior.
     #[inline]
     pub(crate) unsafe fn from_raw(ptr: ptr::NonNull<GreenTokenData>) -> GreenToken {
-        let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
-        let arc = mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc);
+        let arc = unsafe {
+            let arc = Arc::from_raw(&ptr.as_ref().data as *const ReprThin);
+            mem::transmute::<Arc<ReprThin>, ThinArc<GreenTokenHead, u8>>(arc)
+        };
         GreenToken { ptr: arc }
     }
 }

--- a/src/green/token.rs
+++ b/src/green/token.rs
@@ -19,7 +19,6 @@ struct GreenTokenHead {
     _c: Count<GreenToken>,
 }
 
-type Repr = HeaderSlice<GreenTokenHead, [u8]>;
 type ReprThin = HeaderSlice<GreenTokenHead, [u8; 0]>;
 #[repr(transparent)]
 pub struct GreenTokenData {
@@ -96,7 +95,15 @@ impl GreenTokenData {
     /// Text of this Token.
     #[inline]
     pub fn text(&self) -> &str {
-        unsafe { std::str::from_utf8_unchecked(self.data.slice()) }
+        // Access the byte slice via raw pointer arithmetic to avoid going through
+        // Deref on HeaderSlice<H, [u8; 0]> which creates a reference with provenance
+        // limited to the thin type.
+        unsafe {
+            let len = self.data.length;
+            let slice_start = ptr::addr_of!(self.data.slice) as *const u8;
+            let bytes = std::slice::from_raw_parts(slice_start, len);
+            std::str::from_utf8_unchecked(bytes)
+        }
     }
 
     /// Returns the length of the text covered by this token.
@@ -117,8 +124,12 @@ impl GreenToken {
     #[inline]
     pub(crate) fn into_raw(this: GreenToken) -> ptr::NonNull<GreenTokenData> {
         let green = ManuallyDrop::new(this);
-        let green: &GreenTokenData = &green;
-        ptr::NonNull::from(green)
+        // Extract pointer directly from ThinArc to preserve full allocation provenance.
+        let inner = green.ptr.ptr.as_ptr();
+        unsafe {
+            let data = ptr::addr_of!((*inner).data);
+            ptr::NonNull::new_unchecked(data as *mut ReprThin as *mut GreenTokenData)
+        }
     }
 
     /// # Safety
@@ -146,9 +157,8 @@ impl ops::Deref for GreenToken {
     #[inline]
     fn deref(&self) -> &GreenTokenData {
         unsafe {
-            let repr: &Repr = &self.ptr;
-            let repr: &ReprThin = &*(repr as *const Repr as *const ReprThin);
-            mem::transmute::<&ReprThin, &GreenTokenData>(repr)
+            let inner = self.ptr.ptr.as_ptr();
+            &*(ptr::addr_of!((*inner).data) as *const ReprThin as *const GreenTokenData)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,7 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
-        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,8 @@ pub use text_size::{TextLen, TextRange, TextSize};
 
 pub use crate::{
     api::{
-        Language, SyntaxElement, SyntaxElementChildren, SyntaxNode, SyntaxNodeChildren, SyntaxToken,
+        Language, SyntaxElement, SyntaxElementChildren, SyntaxElementChildrenByKind, SyntaxNode,
+        SyntaxNodeChildren, SyntaxNodeChildrenByKind, SyntaxToken,
     },
     green::{
         Checkpoint, Children, GreenNode, GreenNodeBuilder, GreenNodeData, GreenToken,

--- a/src/serde_impls.rs
+++ b/src/serde_impls.rs
@@ -2,8 +2,8 @@ use serde::ser::{Serialize, SerializeMap, SerializeSeq, Serializer};
 use std::fmt;
 
 use crate::{
-    api::{Language, SyntaxNode, SyntaxToken},
     NodeOrToken,
+    api::{Language, SyntaxNode, SyntaxToken},
 };
 
 struct SerDisplay<T>(T);

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -3,6 +3,15 @@
 use std::{cell::Cell, cmp::Ordering, ptr};
 
 use crate::utility_types::Delta;
+
+/// # Safety
+///
+/// Implementors of this trait must ensure that the pointers returned by
+/// `prev` and `next` are valid and properly initialized. The pointers must
+/// point to valid instances of the implementing type or be null pointers.
+/// Additionally, the `key` method must return a valid reference to a `Cell<u32>`.
+///
+/// Failure to uphold these invariants can result in undefined behavior.
 pub(crate) unsafe trait Elem {
     fn prev(&self) -> &Cell<*const Self>;
     fn next(&self) -> &Cell<*const Self>;
@@ -17,7 +26,7 @@ pub(crate) enum AddToSllResult<'a, E: Elem> {
     AlreadyInSll(*const E),
 }
 
-impl<'a, E: Elem> AddToSllResult<'a, E> {
+impl<E: Elem> AddToSllResult<'_, E> {
     pub(crate) fn add_to_sll(&self, elem_ptr: *const E) {
         unsafe {
             (*elem_ptr).prev().set(elem_ptr);
@@ -55,11 +64,7 @@ pub(crate) fn init<'a, E: Elem>(
     head: Option<&'a Cell<*const E>>,
     elem: &E,
 ) -> AddToSllResult<'a, E> {
-    if let Some(head) = head {
-        link(head, elem)
-    } else {
-        AddToSllResult::NoHead
-    }
+    if let Some(head) = head { link(head, elem) } else { AddToSllResult::NoHead }
 }
 
 #[cold]

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -90,7 +90,6 @@ pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllR
         return AddToSllResult::EmptyHead(head);
     }
     unsafe {
-
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {
             return AddToSllResult::SmallerThanHead(head);

--- a/src/sll.rs
+++ b/src/sll.rs
@@ -84,12 +84,12 @@ pub(crate) fn unlink<E: Elem>(head: &Cell<*const E>, elem: &E) {
 
 #[cold]
 pub(crate) fn link<'a, E: Elem>(head: &'a Cell<*const E>, elem: &E) -> AddToSllResult<'a, E> {
+    let old_head = head.get();
+    // Case 1: empty head, replace it.
+    if old_head.is_null() {
+        return AddToSllResult::EmptyHead(head);
+    }
     unsafe {
-        let old_head = head.get();
-        // Case 1: empty head, replace it.
-        if old_head.is_null() {
-            return AddToSllResult::EmptyHead(head);
-        }
 
         // Case 2: we are smaller than the head, replace it.
         if elem.key() < (*old_head).key() {

--- a/src/syntax_text.rs
+++ b/src/syntax_text.rs
@@ -105,7 +105,7 @@ impl SyntaxText {
         }
     }
 
-    fn tokens_with_ranges(&self) -> impl Iterator<Item = (SyntaxToken, TextRange)> {
+    fn tokens_with_ranges(&self) -> impl Iterator<Item = (SyntaxToken, TextRange)> + use<> {
         let text_range = self.range;
         self.node.descendants_with_tokens().filter_map(|element| element.into_token()).filter_map(
             move |token| {

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -43,8 +43,8 @@ impl<N, T> NodeOrToken<N, T> {
 impl<N: Deref, T: Deref> NodeOrToken<N, T> {
     pub(crate) fn as_deref(&self) -> NodeOrToken<&N::Target, &T::Target> {
         match self {
-            NodeOrToken::Node(node) => NodeOrToken::Node(&*node),
-            NodeOrToken::Token(token) => NodeOrToken::Token(&*token),
+            NodeOrToken::Node(node) => NodeOrToken::Node(node),
+            NodeOrToken::Token(token) => NodeOrToken::Token(token),
         }
     }
 }

--- a/src/utility_types.rs
+++ b/src/utility_types.rs
@@ -149,14 +149,6 @@ impl<T> Iterator for TokenAtOffset<T> {
 
 impl<T> ExactSizeIterator for TokenAtOffset<T> {}
 
-macro_rules! _static_assert {
-    ($expr:expr) => {
-        const _: i32 = 0 / $expr as i32;
-    };
-}
-
-pub(crate) use _static_assert as static_assert;
-
 #[derive(Copy, Clone, Debug)]
 pub(crate) enum Delta<T> {
     Add(T),

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -7,3 +7,6 @@ edition = "2021"
 
 [dependencies]
 xaction = "0.2"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -3,10 +3,8 @@ name = "xtask"
 version = "0.0.0"
 publish = false
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
-edition = "2021"
+edition = "2024"
 
 [dependencies]
-xaction = "0.2"
-
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(trick_rust_analyzer_into_highlighting_interpolated_bits)'] }
+anyhow = "1.0.96"
+xshell = "0.2.7"

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -1,6 +1,13 @@
-use std::env;
+use std::{
+    env,
+    path::PathBuf,
+    sync::atomic::{AtomicBool, Ordering},
+    time::{Duration, Instant},
+};
 
-use xaction::{cargo_toml, cmd, git, section, Result};
+use anyhow::anyhow;
+use xshell::{Shell, cmd};
+pub type Result<T> = anyhow::Result<T>;
 
 fn main() {
     if let Err(err) = try_main() {
@@ -9,42 +16,161 @@ fn main() {
     }
 }
 
+pub struct Section {
+    name: &'static str,
+    start: Instant,
+}
+
+pub struct CargoToml {
+    path: PathBuf,
+    contents: String,
+}
+
+impl CargoToml {
+    pub fn version(&self) -> Result<&str> {
+        self.get("version")
+    }
+
+    fn get(&self, field: &str) -> Result<&str> {
+        for line in self.contents.lines() {
+            let words = line.split_ascii_whitespace().collect::<Vec<_>>();
+            match words.as_slice() {
+                [n, "=", v, ..] if n.trim() == field => {
+                    assert!(v.starts_with('"') && v.ends_with('"'));
+                    return Ok(&v[1..v.len() - 1]);
+                }
+                _ => (),
+            }
+        }
+        Err(anyhow!("can't find `{}` in {}", field, self.path.display()))?
+    }
+
+    pub fn publish(&self, sh: &mut Shell) -> Result<()> {
+        let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
+        let dry_run = dry_run();
+        cmd!(sh, "cargo publish --token {token} {dry_run...}").run()?;
+        Ok(())
+    }
+
+    pub fn publish_all(&self, dirs: &[&str], sh: &mut Shell) -> Result<()> {
+        let token = env::var("CRATES_IO_TOKEN").unwrap_or("no token".to_string());
+        if dry_run().is_none() {
+            for &dir in dirs {
+                for _ in 0..20 {
+                    std::thread::sleep(Duration::from_secs(10));
+                    if cmd!(
+                        sh,
+                        "cargo publish --manifest-path {dir}'/Cargo.toml' --token {token} --dry-run"
+                    )
+                    .run()
+                    .is_ok()
+                    {
+                        break;
+                    }
+                }
+                cmd!(sh, "cargo publish --manifest-path {dir}'/Cargo.toml' --token {token}")
+                    .run()?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn dry_run() -> Option<&'static str> {
+    let dry_run = DRY_RUN.load(Ordering::Relaxed);
+    if dry_run { Some("--dry-run") } else { None }
+}
+
+pub fn section(name: &'static str) -> Section {
+    Section::new(name)
+}
+
+pub fn cargo_toml() -> Result<CargoToml> {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
+    let path = PathBuf::from(manifest_dir).join("Cargo.toml");
+    let contents = std::fs::read_to_string(&path)?;
+    Ok(CargoToml { path, contents })
+}
+
+static DRY_RUN: AtomicBool = AtomicBool::new(false);
+pub fn set_dry_run(yes: bool) {
+    DRY_RUN.store(yes, Ordering::Relaxed)
+}
+
 fn try_main() -> Result<()> {
+    let mut sh = Shell::new()?;
     let subcommand = std::env::args().nth(1);
     match subcommand {
         Some(it) if it == "ci" => (),
         _ => {
             print_usage();
-            Err("invalid arguments")?
+            Err(anyhow!("invalid arguments"))?
         }
     }
-
     let cargo_toml = cargo_toml()?;
-
-    {
-        let _s = section("BUILD");
-        cmd!("cargo test --workspace --no-run").run()?;
-    }
-
     {
         let _s = section("TEST");
-        cmd!("cargo test --workspace -- --nocapture").run()?;
+        for &release in &[None, Some("--release")] {
+            cmd!(sh, "cargo test {release...} --workspace -- --nocapture").run()?;
+        }
     }
 
     let version = cargo_toml.version()?;
     let tag = format!("v{}", version);
 
-    let dry_run =
-        env::var("CI").is_err() || git::has_tag(&tag)? || git::current_branch()? != "master";
-    xaction::set_dry_run(dry_run);
+    let dry_run = env::var("CI").is_err()
+        || git::has_tag(&tag, &mut sh)?
+        || git::current_branch(&mut sh)? != "master";
+    set_dry_run(dry_run);
 
     {
         let _s = section("PUBLISH");
-        cargo_toml.publish()?;
-        git::tag(&tag)?;
-        git::push_tags()?;
+        cargo_toml.publish(&mut sh)?;
+        git::tag(&tag, &mut sh)?;
+        git::push_tags(&mut sh)?;
     }
     Ok(())
+}
+
+pub mod git {
+    use xshell::{Shell, cmd};
+
+    use super::{Result, dry_run};
+
+    pub fn current_branch(sh: &mut Shell) -> Result<String> {
+        let res = cmd!(sh, "git branch --show-current").read()?;
+        Ok(res)
+    }
+
+    pub fn tag_list(sh: &mut Shell) -> Result<Vec<String>> {
+        let tags = cmd!(sh, "git tag --list").read()?;
+        let res = tags.lines().map(|it| it.trim().to_string()).collect();
+        Ok(res)
+    }
+
+    pub fn has_tag(tag: &str, sh: &mut Shell) -> Result<bool> {
+        let res = tag_list(sh)?.iter().any(|it| it == tag);
+        Ok(res)
+    }
+
+    pub fn tag(tag: &str, sh: &mut Shell) -> Result<()> {
+        if dry_run().is_some() {
+            return Ok(());
+        }
+        cmd!(sh, "git tag {tag}").run()?;
+        Ok(())
+    }
+
+    pub fn push_tags(sh: &mut Shell) -> Result<()> {
+        // `git push --tags --dry-run` exists, but it will fail with permissions
+        // error for forks.
+        if dry_run().is_some() {
+            return Ok(());
+        }
+
+        cmd!(sh, "git push --tags").run()?;
+        Ok(())
+    }
 }
 
 fn print_usage() {
@@ -56,4 +182,19 @@ SUBCOMMANDS:
     ci
 "
     )
+}
+
+impl Section {
+    fn new(name: &'static str) -> Section {
+        println!("::group::{}", name);
+        let start = Instant::now();
+        Section { name, start }
+    }
+}
+
+impl Drop for Section {
+    fn drop(&mut self) {
+        eprintln!("{}: {:.2?}", self.name, self.start.elapsed());
+        println!("::endgroup::");
+    }
 }

--- a/xtask/tests/tidy.rs
+++ b/xtask/tests/tidy.rs
@@ -1,6 +1,7 @@
-use xaction::cmd;
+use xshell::{Shell, cmd};
 
 #[test]
 fn test_formatting() {
-    cmd!("cargo fmt --all -- --check").run().unwrap()
+    let sh = Shell::new().unwrap();
+    cmd!(sh, "cargo fmt --all -- --check").run().unwrap()
 }


### PR DESCRIPTION
Hi — we use rowan in two safety-critical projects (rivet, spar) and ran into the Miri UB documented in #192, #163, #108. We took a shot at fixing it and would appreciate your feedback on the approach.

## What this changes

The core issue is that Miri's borrow models (stacked and tree borrows) flag provenance violations when:
- References to thin types (`HeaderSlice<H, [T; 0]>`) are used to access data beyond the thin layout
- `&NodeData` containing Cell fields freezes the allocation tag, preventing later deallocation
- Refcount access via `Cell::get()` or `&ArcInner` creates references that narrow provenance

The fix touches 4 files (+152/-63 lines):
- **arc.rs**: refcount access via raw pointers instead of `&ArcInner` references; ThinArc clone/drop without transient Arc
- **green/node.rs**: `GreenNodeData` wraps fat `Repr` (unsized) so provenance covers the full slice; `into_raw` extracts pointer from ThinArc directly
- **green/token.rs**: `text()` via raw pointer arithmetic; `into_raw`/`deref` via ThinArc pointer
- **cursor.rs**: SyntaxNode/Token ptr in `UnsafeCell`; `NodeData::self_alloc` field preserves original allocation provenance for deallocation; refcount decrement via raw `*mut u32`

## What we DON'T know

- **Performance impact**: We haven't benchmarked. The `self_alloc` field adds 8 bytes per NodeData. The UnsafeCell wrapper and raw pointer access patterns might affect optimization. We'd really appreciate if you could run your benchmarks.
- **Mutable tree path**: The `clone_for_update` tests (`ensure_mut_*`) still fail under Miri. Our fix focuses on the immutable tree path. The mutable path has additional provenance issues in the singly-linked list infrastructure.
- **Whether this is the right approach**: We chose minimal, targeted changes over a larger refactor. There might be cleaner designs (e.g., making the cursor fully raw-pointer-based). We're open to feedback.

## Testing

- `cargo test --lib` — 6/6 pass
- `cargo +nightly miri test --lib -- --skip ensure_mut` — 4/4 pass under `-Zmiri-tree-borrows`
- Under stacked borrows, the immutable path still has issues due to the stricter model
- Tested in downstream: rivet (26 yaml_cst tests pass Miri), spar

Happy to iterate on this based on your feedback. Thank you for maintaining rowan — it's a great library.