### PR TITLE
Add tree top to rowan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rowan"
-version = "0.15.18"
+version = "0.15.19"
 authors = ["Aleksey Kladov <aleksey.kladov@gmail.com>"]
 repository = "https://github.com/rust-analyzer/rowan"
 license = "MIT OR Apache-2.0"

--- a/src/api.rs
+++ b/src/api.rs
@@ -133,6 +133,10 @@ impl<L: Language> SyntaxNode<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
+    pub fn tree_top(&self) -> SyntaxNode<L> {
+        SyntaxNode::from(self.raw.tree_top())
+    }
+
     pub fn children(&self) -> SyntaxNodeChildren<L> {
         SyntaxNodeChildren { raw: self.raw.children(), _p: PhantomData }
     }
@@ -301,6 +305,10 @@ impl<L: Language> SyntaxToken<L> {
         self.raw.ancestors().map(SyntaxNode::from)
     }
 
+    pub fn tree_top(&self) -> SyntaxNode<L> {
+        SyntaxNode::from(self.raw.tree_top())
+    }
+
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<L>> {
         self.raw.next_sibling_or_token().map(NodeOrToken::from)
     }
@@ -364,6 +372,13 @@ impl<L: Language> SyntaxElement<L> {
             NodeOrToken::Token(it) => it.parent(),
         };
         iter::successors(first, SyntaxNode::parent)
+    }
+
+    pub fn tree_top(&self) -> SyntaxNode<L> {
+        match self {
+            NodeOrToken::Node(it) => it.tree_top(),
+            NodeOrToken::Token(it) => it.tree_top(),
+        }
     }
 
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement<L>> {

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -630,6 +630,11 @@ impl SyntaxNode {
     }
 
     #[inline]
+    pub fn tree_top(&self) -> SyntaxNode {
+        self.ancestors().last().unwrap()
+    }
+
+    #[inline]
     pub fn children(&self) -> SyntaxNodeChildren {
         SyntaxNodeChildren::new(self.clone())
     }
@@ -911,6 +916,11 @@ impl SyntaxToken {
         std::iter::successors(self.parent(), SyntaxNode::parent)
     }
 
+    #[inline]
+    pub fn tree_top(&self) -> SyntaxNode {
+        self.ancestors().last().unwrap()
+    }
+
     pub fn next_sibling_or_token(&self) -> Option<SyntaxElement> {
         self.data().next_sibling_or_token()
     }
@@ -1011,6 +1021,14 @@ impl SyntaxElement {
             NodeOrToken::Token(it) => it.parent(),
         };
         iter::successors(first, SyntaxNode::parent)
+    }
+
+    #[inline]
+    pub fn tree_top(&self) -> SyntaxNode {
+        match self {
+            NodeOrToken::Node(it) => it.tree_top(),
+            NodeOrToken::Token(it) => it.tree_top(),
+        }
     }
 
     pub fn first_token(&self) -> Option<SyntaxToken> {


### PR DESCRIPTION
Adding tree_top method for SyntaxNode/Token/Element, more info here: https://github.com/rust-lang/rust-analyzer/pull/22668,

This is based out of v0.15.18, and does a patch to v0.15.19